### PR TITLE
Rozdelený layout na front-page.php a archive-product.php.

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -85,7 +85,7 @@ a:hover{
 
 /* Hlavný obsah */
 .site-main{
-  padding: 0px 0 24px;
+  padding: 24px 0 24px;
 }
 
 .entry-card{

--- a/assets/css/woocommerce.css
+++ b/assets/css/woocommerce.css
@@ -2,11 +2,19 @@
    WOOCOMMERCE – product archive / grid
 ======================================== */
 
+/* spoločné cesty pre WooCommerce archívy */
+.post-type-archive-product,
+.tax-product_cat,
+.tax-product_tag {
+  --jt-shop-max: 1360px;
+  --jt-shop-gap: 32px;
+}
+
 /* hlavný wrapper sekcie */
 .post-type-archive-product .site-container,
 .tax-product_cat .site-container,
 .tax-product_tag .site-container {
-  width: min(100% - 32px, 1360px);
+  width: min(100% - var(--jt-shop-gap), var(--jt-shop-max));
   margin-inline: auto;
 }
 
@@ -16,7 +24,63 @@
 .tax-product_tag .site-main {
   max-width: 100%;
   margin: 0 auto;
+  padding: 12px 0 12px; /* medzera pod headerom / menu */
+}
+
+/* archive layout: sidebar + content */
+.shop-archive-layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+/* sidebar */
+.shop-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.shop-sidebar .entry-card,
+.shop-filter-box,
+.shop-quick-links {
+  background: #fff;
+  border: 1px solid var(--jt-line, #dbe3ee);
+  border-radius: 24px;
+  padding: 24px 20px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04);
+  box-sizing: border-box;
+}
+
+.shop-sidebar h3 {
+  margin: 0 0 14px;
+  font-size: 1.1rem;
+  line-height: 1.3;
+}
+
+.shop-quick-links ul {
+  margin: 0;
   padding: 0;
+  list-style: none;
+}
+
+.shop-quick-links li + li {
+  margin-top: 10px;
+}
+
+.shop-quick-links a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.shop-quick-links a:hover {
+  text-decoration: underline;
+}
+
+/* obsah produktov */
+.shop-archive-content {
+  min-width: 0;
 }
 
 /* veľký box sekcie */
@@ -45,14 +109,14 @@
   display: none !important;
 }
 
-/* zoznam produktov – GRID */
+/* základ gridu */
 .woocommerce ul.products {
   display: grid !important;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 18px;
   margin: 0;
   padding: 0;
   list-style: none;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
 /* homepage – 5 produktov */
@@ -60,7 +124,7 @@
   grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
-/* archive / kategórie / tagy – 5 produktov a potom prechod na 4 produkty */
+/* archívy kategórií / tagov / shop – 4 produkty */
 .post-type-archive-product .woocommerce ul.products,
 .tax-product_cat .woocommerce ul.products,
 .tax-product_tag .woocommerce ul.products {
@@ -115,47 +179,48 @@
 
 /* tablet */
 @media (max-width: 1200px) {
-  .woocommerce ul.products,
-  .home .woocommerce ul.products,
-  .post-type-archive-product .woocommerce ul.products,
-  .tax-product_cat .woocommerce ul.products,
-  .tax-product_tag .woocommerce ul.products {
+  .shop-archive-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .woocommerce ul.products {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
 /* menší tablet */
 @media (max-width: 900px) {
-  .woocommerce ul.products,
-  .home .woocommerce ul.products,
-  .post-type-archive-product .woocommerce ul.products,
-  .tax-product_cat .woocommerce ul.products,
-  .tax-product_tag .woocommerce ul.products {
+  .woocommerce ul.products {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 /* mobil */
 @media (max-width: 640px) {
-  .post-type-archive-product .site-container,
-  .tax-product_cat .site-container,
-  .tax-product_tag .site-container {
-    width: min(100% - 20px, 1360px);
+  .post-type-archive-product,
+  .tax-product_cat,
+  .tax-product_tag {
+    --jt-shop-gap: 20px;
+  }
+
+  .post-type-archive-product .site-main,
+  .tax-product_cat .site-main,
+  .tax-product_tag .site-main {
+    padding: 16px 0 0;
   }
 
   .post-type-archive-product .woocommerce,
   .tax-product_cat .woocommerce,
-  .tax-product_tag .woocommerce {
+  .tax-product_tag .woocommerce,
+  .shop-sidebar .entry-card,
+  .shop-filter-box,
+  .shop-quick-links {
     padding: 20px 16px 24px;
     border-radius: 18px;
   }
 
-  .woocommerce ul.products,
-  .home .woocommerce ul.products,
-  .post-type-archive-product .woocommerce ul.products,
-  .tax-product_cat .woocommerce ul.products,
-  .tax-product_tag .woocommerce ul.products {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .woocommerce ul.products {
     gap: 12px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/front-page.php
+++ b/front-page.php
@@ -1,0 +1,16 @@
+<?php get_header(); ?>
+
+<main class="site-main front-page">
+
+<?php
+while ( have_posts() ) :
+    the_post();
+    the_content();
+endwhile;
+?>
+
+<?php get_template_part('template-parts/shop-home-entry'); ?>
+
+</main>
+
+<?php get_footer(); ?>

--- a/functions.php
+++ b/functions.php
@@ -28,6 +28,9 @@ function jtcollector_theme_setup(): void
 		'script',
 	]);
 
+	// WooCommerce support
+	add_theme_support('woocommerce');
+
 	register_nav_menus([
 		'header_about_menu' => __('Header About Menu', 'jtcollector'),
 		'header_info_menu'  => __('Header Info Menu', 'jtcollector'),
@@ -67,6 +70,14 @@ function jtcollector_enqueue_assets(): void
 		filemtime(get_template_directory() . '/assets/css/shop-home-entry.css')
 	);
 
+	// WOOCOMMERCE STYLE
+	wp_enqueue_style(
+		'jtcollector-woocommerce',
+		get_template_directory_uri() . '/assets/css/woocommerce.css',
+		['jtcollector-main-style'],
+		filemtime(get_template_directory() . '/assets/css/woocommerce.css')
+	);
+
 	// HEADER SCRIPT
 	wp_enqueue_script(
 		'jtcollector-header-script',
@@ -76,35 +87,4 @@ function jtcollector_enqueue_assets(): void
 		true
 	);
 }
-
-// WOOCOMMERCE STYLE
-wp_enqueue_style(
-    'jtcollector-woocommerce',
-    get_template_directory_uri() . '/assets/css/woocommerce.css',
-    [],
-    '1.0'
-);
-
-// Shop filer widget na shop stránke, kategóriách a tagoch
-add_action('woocommerce_before_shop_loop', 'jtcollector_render_shop_filters', 5);
-
-function jtcollector_render_shop_filters() {
-    if ( ! is_shop() && ! is_product_category() && ! is_product_tag() ) {
-        return;
-    }
-
-    echo '<aside class="shop-filter">';
-    echo '<h3>Filtrovať</h3>';
-
-    if ( shortcode_exists('yith_wcan_filters') ) {
-        echo do_shortcode('[yith_wcan_filters slug="default-preset"]');
-    }
-
-    if ( class_exists('WC_Widget_Price_Filter') ) {
-        the_widget('WC_Widget_Price_Filter');
-    }
-
-    echo '</aside>';
-}
-
 add_action('wp_enqueue_scripts', 'jtcollector_enqueue_assets');

--- a/index.php
+++ b/index.php
@@ -8,12 +8,13 @@
 get_header();
 ?>
 
-<?php get_template_part('template-parts/shop-home-entry'); ?>
-
 <section class="content-area">
 	<div class="site-container">
-		<?php if (have_posts()) : ?>
-			<?php while (have_posts()) : the_post(); ?>
+
+		<?php if ( have_posts() ) : ?>
+
+			<?php while ( have_posts() ) : the_post(); ?>
+
 				<article id="post-<?php the_ID(); ?>" <?php post_class('entry-card'); ?>>
 					<h1 class="entry-title">
 						<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
@@ -23,13 +24,18 @@ get_header();
 						<?php the_content(); ?>
 					</div>
 				</article>
+
 			<?php endwhile; ?>
+
 		<?php else : ?>
+
 			<article class="entry-card">
 				<h1 class="entry-title"><?php esc_html_e('Nothing found', 'jtcollector'); ?></h1>
 				<p><?php esc_html_e('It looks like there is no content yet.', 'jtcollector'); ?></p>
 			</article>
+
 		<?php endif; ?>
+
 	</div>
 </section>
 

--- a/woocommerce/archive-product.php
+++ b/woocommerce/archive-product.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Custom WooCommerce archive template
+ *
+ * @package JTCollector
+ */
+
+defined('ABSPATH') || exit;
+
+get_header();
+?>
+
+<main class="site-main shop-archive-page">
+	<div class="site-container">
+		<div class="shop-archive-layout">
+
+			<aside class="shop-sidebar">
+				<div class="shop-quick-links entry-card">
+					<h3><?php woocommerce_page_title(); ?> – rýchly výber</h3>
+
+					<?php
+					if (shortcode_exists('yith_wcan_filters')) {
+						echo do_shortcode('[yith_wcan_filters slug="draft-preset-2"]');
+					}
+					?>
+				</div>
+
+				<div class="shop-filter-box entry-card">
+					<h3>Filtrovať</h3>
+
+					<?php
+					if (shortcode_exists('yith_wcan_filters')) {
+						echo do_shortcode('[yith_wcan_filters slug="draft-preset"]');
+					}
+
+					if (class_exists('WC_Widget_Price_Filter')) {
+						the_widget('WC_Widget_Price_Filter');
+					}
+					?>
+				</div>
+			</aside>
+
+			<div class="shop-archive-content entry-card">
+				<?php if (woocommerce_product_loop()) : ?>
+
+					<header class="woocommerce-products-header">
+						<?php if (apply_filters('woocommerce_show_page_title', true)) : ?>
+							<h1 class="woocommerce-products-header__title page-title">
+								<?php woocommerce_page_title(); ?>
+							</h1>
+						<?php endif; ?>
+
+						<?php do_action('woocommerce_archive_description'); ?>
+					</header>
+
+					<div class="shop-archive-toolbar">
+						<?php
+						woocommerce_result_count();
+						woocommerce_catalog_ordering();
+						?>
+					</div>
+
+					<?php
+					woocommerce_product_loop_start();
+
+					if (wc_get_loop_prop('total')) {
+						while (have_posts()) {
+							the_post();
+
+							do_action('woocommerce_shop_loop');
+
+							wc_get_template_part('content', 'product');
+						}
+					}
+
+					woocommerce_product_loop_end();
+
+					do_action('woocommerce_after_shop_loop');
+					?>
+
+				<?php else : ?>
+
+					<?php do_action('woocommerce_no_products_found'); ?>
+
+				<?php endif; ?>
+			</div>
+
+		</div>
+	</div>
+</main>
+
+<?php
+get_footer();


### PR DESCRIPTION
Rozdelený layout na front-page.php a archive-product.php.

Pridaný custom WooCommerce archive-product template pre kategórie produktov.

Layout obsahuje ľavý sidebar s quick-pick presetom a hlavným filtrom cez YITH Ajax Product Filter, spolu s produktovým gridom vpravo. Quick-pick a main-filter boli oddelené do samostatných presetov.

Zároveň bol upravený WooCommerce layout pre zobrazenie 4 produktov v riadku a zachovaný prehľadný sidebar pre kategórie ako Hokej, Futbal a MMA.