### PR TITLE
Vytvorený template pre blog článok

### DIFF
--- a/assets/css/page-content.css
+++ b/assets/css/page-content.css
@@ -1,7 +1,7 @@
 /* ========================================
    PAGE / CONTENT LAYOUT
    Base wrapper pre statické stránky,
-   Gutenberg obsah a neskôr aj single post
+   Gutenberg obsah a single post
 ======================================== */
 
 .site-page {
@@ -10,7 +10,7 @@
 }
 
 .page-entry {
-  padding: 0px 0 0px; /* je v main.css */
+  padding: 0; /* vertikálny spacing je v main.css */
 }
 
 .page-entry__inner {
@@ -42,6 +42,8 @@
 
 .page-entry__content {
   min-width: 0;
+  font-size: 1.1rem;
+  line-height: 1.7;
 }
 
 .page-entry__content > *:first-child {
@@ -52,10 +54,97 @@
   margin-bottom: 0;
 }
 
+/* ========================================
+   SINGLE POST
+======================================== */
+
+.site-single .page-entry__main {
+  padding-top: 32px;
+}
+
+.single-entry__header {
+  margin-bottom: 32px;
+}
+
+.single-entry__hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 32px;
+}
+
+.single-entry__hero-content {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.single-entry__title {
+  margin-bottom: 18px;
+  color: var(--jt-primary-dark, #1e3a8a);
+}
+
+.single-entry__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 22px;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--jt-muted, #6b7280);
+}
+
+.single-entry__meta-item {
+  color: var(--jt-muted, #6b7280);
+}
+
+.single-entry__meta-separator {
+  color: #94a3b8;
+}
+
+.single-entry__excerpt {
+  font-size: 1.2rem;
+  line-height: 1.7;
+  color: #475569;
+}
+
+.single-entry__excerpt p {
+  margin: 0;
+}
+
+.single-entry__thumbnail {
+  flex: 0 0 500px;
+  max-width: 500px;
+  width: 100%;
+}
+
+.single-entry__image {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 20px;
+  object-fit: cover;
+}
+
+/* obsah článku */
+.single-entry__content {
+  min-width: 0;
+}
+
 /* tablet */
 @media (max-width: 900px) {
   .page-entry__main {
     padding: 24px 22px 28px;
+  }
+
+  .single-entry__hero {
+    flex-direction: column;
+  }
+
+  .single-entry__thumbnail {
+    flex: none;
+    max-width: 100%;
+    width: 100%;
   }
 }
 
@@ -65,10 +154,6 @@
     --jt-page-gap: 20px;
   }
 
-  .page-entry {
-    padding: 20px 0 24px;
-  }
-
   .page-entry__main {
     padding: 20px 16px 24px;
     border-radius: 18px;
@@ -76,5 +161,32 @@
 
   .page-entry__title {
     font-size: 2rem;
+  }
+
+  .page-entry__content {
+    font-size: 1.02rem;
+    line-height: 1.65;
+  }
+
+  .single-entry__header {
+    margin-bottom: 24px;
+  }
+
+  .single-entry__hero {
+    gap: 20px;
+  }
+
+  .single-entry__meta {
+    gap: 8px;
+    margin-bottom: 18px;
+    font-size: 0.95rem;
+  }
+
+  .single-entry__excerpt {
+    font-size: 1.05rem;
+  }
+
+  .single-entry__image {
+    border-radius: 16px;
   }
 }

--- a/single.php
+++ b/single.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Single post template
+ *
+ * @package JTCollector
+ */
+
+defined('ABSPATH') || exit;
+
+get_header();
+?>
+
+<main class="site-main site-page site-single">
+	<?php if (have_posts()) : ?>
+		<?php while (have_posts()) : the_post(); ?>
+			<section class="page-entry single-entry">
+				<div class="page-entry__inner">
+					<article <?php post_class('page-entry__main single-entry__main entry-card'); ?>>
+
+						<header class="page-entry__header single-entry__header">
+							<div class="single-entry__hero">
+								<div class="single-entry__hero-content">
+									<h1 class="page-entry__title single-entry__title"><?php the_title(); ?></h1>
+
+									<div class="single-entry__meta">
+										<span class="single-entry__meta-item">
+											<?php echo esc_html(get_the_date('j. F Y')); ?>
+										</span>
+
+										<span class="single-entry__meta-separator">•</span>
+
+										<span class="single-entry__meta-item">
+											<?php the_author(); ?>
+										</span>
+
+										<?php
+										$categories = get_the_category();
+										if (!empty($categories)) :
+										?>
+											<span class="single-entry__meta-separator">•</span>
+											<span class="single-entry__meta-item">
+												<?php echo esc_html($categories[0]->name); ?>
+											</span>
+										<?php endif; ?>
+									</div>
+
+									<?php if (has_excerpt()) : ?>
+										<div class="single-entry__excerpt">
+											<?php the_excerpt(); ?>
+										</div>
+									<?php endif; ?>
+								</div>
+
+								<?php if (has_post_thumbnail()) : ?>
+									<div class="single-entry__thumbnail">
+										<?php the_post_thumbnail('large', ['class' => 'single-entry__image']); ?>
+									</div>
+								<?php endif; ?>
+							</div>
+						</header>
+
+						<div class="page-entry__content single-entry__content entry-content">
+							<?php the_content(); ?>
+						</div>
+
+					</article>
+				</div>
+			</section>
+		<?php endwhile; ?>
+	<?php endif; ?>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Popis

Implementovaná šablóna pre blogové články (`single.php`) spolu s rozšírením existujúceho content layoutu v `page-content.css`.

Cieľom bolo vytvoriť jednotný a prehľadný layout článku, ktorý bude vizuálne konzistentný so zvyškom stránky a zároveň pripravený na Gutenberg obsah.

## Zmeny

- vytvorený súbor `single.php` pre zobrazenie blogových článkov
- pridaný hero layout článku:
  - názov článku
  - meta informácie (dátum, autor, kategória)
  - voliteľné zhrnutie (excerpt)
  - featured image zobrazený vedľa textu
- rozšírený `page-content.css`:
  - doplnené štýly pre single článok (`.single-entry__*`)
  - upravený layout hero sekcie (flex – text + obrázok)
  - responzívne správanie (stack na mobile)
- upravená typografia obsahu:
  - globálne zväčšený text v `.page-entry__content`
  - lepšia čitateľnosť pre blog aj statické stránky (OOU, OP)

## Výsledok

- blogové články majú moderný a prehľadný layout
- jednotný content wrapper pre všetky typy stránok
- lepšia čitateľnosť obsahu
- pripravený základ pre:
  - Issue #6 (Gutenberg content styling)
  - budúce rozšírenia blogu (napr. listing, kategórie)

## Poznámka

Obrázky v obsahu článkov (galérie, inline obrázky) sú zatiaľ spravované priamo cez Gutenberg editor. Ich detailný styling bude riešený v rámci Issue #6.