### PR TITLE
Pridanie šablón pre výpis blogových článkov a kategórií

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -1,0 +1,105 @@
+/**
+ * Blog - Archive template
+ *
+ * @package JTCollector
+ */
+
+defined('ABSPATH') || exit;
+
+get_header();
+?>
+
+<main class="site-main site-page site-archive">
+	<section class="page-entry archive-entry">
+		<div class="page-entry__inner">
+			<div class="page-entry__main archive-entry__main entry-card">
+
+				<header class="page-entry__header archive-entry__header">
+					<h1 class="page-entry__title archive-entry__title">
+						<?php post_type_archive_title(); ?>
+					</h1>
+
+					<div class="archive-entry__intro page-entry__content">
+						<p>
+							Nájdete tu články zo zberateľského sveta, moje postrehy, rady pre nových aj skúsenejších zberateľov
+							a množstvo zaujímavostí zo zákulisia zberateľstva. Čítajte, vzdelávajte sa a nechajte sa inšpirovať
+							na vlastnej zberateľskej ceste.
+						</p>
+					</div>
+				</header>
+
+				<?php if (have_posts()) : ?>
+					<div class="archive-list">
+						<?php while (have_posts()) : the_post(); ?>
+							<article <?php post_class('archive-card'); ?>>
+								<a class="archive-card__media" href="<?php the_permalink(); ?>" aria-label="<?php echo esc_attr(get_the_title()); ?>">
+									<?php if (has_post_thumbnail()) : ?>
+										<?php the_post_thumbnail('large', ['class' => 'archive-card__image']); ?>
+									<?php else : ?>
+										<div class="archive-card__image archive-card__image--placeholder"></div>
+									<?php endif; ?>
+								</a>
+
+								<div class="archive-card__content">
+									<h2 class="archive-card__title">
+										<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+									</h2>
+
+									<div class="archive-card__meta">
+										<span class="archive-card__meta-item">
+											<?php echo esc_html(get_the_date('j. n. Y')); ?>
+										</span>
+
+										<span class="archive-card__meta-separator">•</span>
+
+										<span class="archive-card__meta-item">
+											<?php the_author(); ?>
+										</span>
+
+										<?php
+										$categories = get_the_category();
+										if (!empty($categories)) :
+										?>
+											<span class="archive-card__meta-separator">•</span>
+											<span class="archive-card__meta-item">
+												<?php echo esc_html($categories[0]->name); ?>
+											</span>
+										<?php endif; ?>
+									</div>
+
+									<div class="archive-card__excerpt">
+										<?php
+										if (has_excerpt()) {
+											the_excerpt();
+										} else {
+											echo '<p>' . esc_html(wp_trim_words(get_the_excerpt(), 28, '...')) . '</p>';
+										}
+										?>
+									</div>
+
+									<a class="archive-card__link" href="<?php the_permalink(); ?>">
+										Čítať článok
+									</a>
+								</div>
+							</article>
+						<?php endwhile; ?>
+					</div>
+
+					<?php the_posts_pagination([
+						'mid_size'  => 1,
+						'prev_text' => '← Predchádzajúca',
+						'next_text' => 'Ďalšia →',
+					]); ?>
+
+				<?php else : ?>
+					<div class="archive-entry__empty page-entry__content">
+						<p>Zatiaľ tu nie sú žiadne články.</p>
+					</div>
+				<?php endif; ?>
+
+			</div>
+		</div>
+	</section>
+</main>
+
+<?php get_footer(); ?>

--- a/assets/css/page-content.css
+++ b/assets/css/page-content.css
@@ -1,7 +1,7 @@
 /* ========================================
    PAGE / CONTENT LAYOUT
    Base wrapper pre statické stránky,
-   Gutenberg obsah a single post
+   Gutenberg obsah, single post a archive
 ======================================== */
 
 .site-page {
@@ -126,9 +126,169 @@
   object-fit: cover;
 }
 
-/* obsah článku */
 .single-entry__content {
   min-width: 0;
+}
+
+/* ========================================
+   ARCHIVE / CATEGORY
+======================================== */
+
+.archive-entry__header {
+  margin-bottom: 12px;
+}
+
+.archive-entry__title {
+  margin-bottom: 16px;
+}
+
+.archive-entry__intro {
+  max-width: 1000px;
+  margin-bottom: 8px;
+}
+
+.archive-list {
+  margin-top: 8px;
+}
+
+.archive-card {
+  display: grid;
+  grid-template-columns: minmax(220px, 32%) minmax(0, 1fr);
+  gap: 28px;
+  align-items: start;
+  padding: 28px 0;
+}
+
+.archive-card + .archive-card {
+  border-top: 2px solid #d9e9fb;
+}
+
+.archive-card__media {
+  display: block;
+  text-decoration: none;
+}
+
+.archive-card__image {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.archive-card__image--placeholder {
+  border: 1px solid var(--jt-line, #dbe3ee);
+}
+
+.archive-card__content {
+  min-width: 0;
+  padding-top: 4px;
+}
+
+.archive-card__title {
+  margin: 0 0 14px;
+  font-size: clamp(1.55rem, 2.2vw, 2.35rem);
+  line-height: 1.15;
+  font-weight: 800;
+}
+
+.archive-card__title a {
+  color: var(--jt-ink, #0f172a);
+  text-decoration: none;
+}
+
+.archive-card__title a:hover,
+.archive-card__title a:focus-visible {
+  color: var(--jt-primary-dark, #1e3a8a);
+}
+
+.archive-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--jt-muted, #6b7280);
+}
+
+.archive-card__meta-item {
+  color: var(--jt-muted, #6b7280);
+}
+
+.archive-card__meta-separator {
+  color: #94a3b8;
+}
+
+.archive-card__excerpt {
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 18px;
+}
+
+.archive-card__excerpt p {
+  margin: 0;
+}
+
+.archive-card__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 0 22px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #3095e8 0%, #194b9b 100%);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.archive-card__link:hover,
+.archive-card__link:focus-visible {
+  opacity: 0.94;
+  transform: translateY(-1px);
+  color: #fff;
+}
+
+.archive-entry__empty {
+  padding: 12px 0 4px;
+}
+
+.navigation.pagination {
+  margin-top: 8px;
+  padding-top: 24px;
+  border-top: 2px solid #d9e9fb;
+}
+
+.navigation.pagination .nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.navigation.pagination .page-numbers {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 14px;
+  border: 1px solid var(--jt-line, #dbe3ee);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--jt-ink, #0f172a);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.navigation.pagination .page-numbers.current {
+  background: var(--jt-primary, #1d4ed8);
+  border-color: var(--jt-primary, #1d4ed8);
+  color: #fff;
 }
 
 /* tablet */
@@ -145,6 +305,15 @@
     flex: none;
     max-width: 100%;
     width: 100%;
+  }
+
+  .archive-card {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .archive-card__image {
+    aspect-ratio: 16 / 9;
   }
 }
 
@@ -188,5 +357,29 @@
 
   .single-entry__image {
     border-radius: 16px;
+  }
+
+  .archive-card {
+    padding: 22px 0;
+  }
+
+  .archive-card__title {
+    font-size: 1.7rem;
+  }
+
+  .archive-card__meta {
+    gap: 8px;
+    margin-bottom: 14px;
+    font-size: 0.95rem;
+  }
+
+  .archive-card__excerpt {
+    font-size: 1rem;
+    line-height: 1.65;
+    margin-bottom: 16px;
+  }
+
+  .archive-card__link {
+    width: 100%;
   }
 }

--- a/category.php
+++ b/category.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Blog - Category archive template
+ *
+ * @package JTCollector
+ */
+
+defined('ABSPATH') || exit;
+
+get_header();
+?>
+
+<main class="site-main site-page site-archive site-category">
+	<section class="page-entry archive-entry">
+		<div class="page-entry__inner">
+			<div class="page-entry__main archive-entry__main entry-card">
+
+				<header class="page-entry__header archive-entry__header">
+					<h1 class="page-entry__title archive-entry__title">
+						<?php single_cat_title(); ?>
+					</h1>
+
+					<?php $category_description = category_description(); ?>
+					<?php if (!empty($category_description)) : ?>
+						<div class="archive-entry__intro page-entry__content">
+							<?php echo wp_kses_post(wpautop($category_description)); ?>
+						</div>
+					<?php endif; ?>
+				</header>
+
+				<?php if (have_posts()) : ?>
+					<div class="archive-list">
+						<?php while (have_posts()) : the_post(); ?>
+							<article <?php post_class('archive-card'); ?>>
+								<a class="archive-card__media" href="<?php the_permalink(); ?>" aria-label="<?php echo esc_attr(get_the_title()); ?>">
+									<?php if (has_post_thumbnail()) : ?>
+										<?php the_post_thumbnail('large', ['class' => 'archive-card__image']); ?>
+									<?php else : ?>
+										<div class="archive-card__image archive-card__image--placeholder"></div>
+									<?php endif; ?>
+								</a>
+
+								<div class="archive-card__content">
+									<h2 class="archive-card__title">
+										<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+									</h2>
+
+									<div class="archive-card__meta">
+										<span class="archive-card__meta-item">
+											<?php echo esc_html(get_the_date('j. n. Y')); ?>
+										</span>
+
+										<span class="archive-card__meta-separator">•</span>
+
+										<span class="archive-card__meta-item">
+											<?php the_author(); ?>
+										</span>
+
+										<?php
+										$categories = get_the_category();
+										if (!empty($categories)) :
+										?>
+											<span class="archive-card__meta-separator">•</span>
+											<span class="archive-card__meta-item">
+												<?php echo esc_html($categories[0]->name); ?>
+											</span>
+										<?php endif; ?>
+									</div>
+
+									<div class="archive-card__excerpt">
+										<?php
+										if (has_excerpt()) {
+											the_excerpt();
+										} else {
+											echo '<p>' . esc_html(wp_trim_words(get_the_excerpt(), 28, '...')) . '</p>';
+										}
+										?>
+									</div>
+
+									<a class="archive-card__link" href="<?php the_permalink(); ?>">
+										Čítať článok
+									</a>
+								</div>
+							</article>
+						<?php endwhile; ?>
+					</div>
+
+					<?php the_posts_pagination([
+						'mid_size'  => 1,
+						'prev_text' => '← Predchádzajúca',
+						'next_text' => 'Ďalšia →',
+					]); ?>
+
+				<?php else : ?>
+					<div class="archive-entry__empty page-entry__content">
+						<p>V tejto kategórii zatiaľ nie sú žiadne články.</p>
+					</div>
+				<?php endif; ?>
+
+			</div>
+		</div>
+	</section>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Popis

Pridané základné šablóny pre výpis blogových článkov a kategórií pomocou `archive.php` a `category.php`, spolu s rozšírením existujúceho `page-content.css` o štýly pre blog archive layout.

Cieľom bolo pripraviť jednotný základ pre blog sekciu, ktorý bude vizuálne konzistentný so zvyškom témy a umožní neskoršie dopracovanie prepojenia cez dynamické menu a WordPress nastavenia stránky pre príspevky.

## Zmeny

- vytvorený súbor `archive.php`
- vytvorený súbor `category.php`
- doplnený layout pre výpis článkov:
  - názov archívu / kategórie
  - úvodný popis
  - zoznam článkov pod sebou
  - featured image vľavo
  - názov, meta informácie a excerpt vpravo
  - odkaz na detail článku
- doplnené stránkovanie výpisu článkov
- rozšírený `page-content.css` o štýly pre:
  - archive header
  - archive list
  - archive cards
  - meta informácie
  - excerpt
  - pagination
- zachovaný spoločný CSS súbor pre page, single aj archive layout

## Výsledok

- pripravený základ pre stránku Blog a kategórie článkov
- jednotný vizuálny štýl naprieč obsahovými šablónami
- základ pre budúce napojenie blog výpisu cez menu a WordPress nastavenia

## Poznámka

Prepojenie položky „Blog“ v headri na dynamický WordPress výpis článkov nebolo súčasťou tejto úlohy a bude riešené samostatne spolu s aktiváciou menu navigácie.