### PR TITLE
single product layout with active according filter

### DIFF
--- a/assets/css/single-product.css
+++ b/assets/css/single-product.css
@@ -1,0 +1,640 @@
+/* ========================================
+   SINGLE PRODUCT
+======================================== */
+
+.single-product {
+  --jt-single-max: 1360px;
+  --jt-single-gap: 32px;
+}
+
+.single-product .site-container {
+  width: min(100% - var(--jt-single-gap), var(--jt-single-max));
+  margin-inline: auto;
+}
+
+.single-product-page {
+  padding: 12px 0;
+}
+
+.jt-single-product {
+  width: 100%;
+}
+
+/* hlavný veľký box */
+.jt-single-product__card {
+  background: #fff;
+  border: 1px solid var(--jt-line, #dbe3ee);
+  border-radius: 24px;
+  padding: 28px 28px 32px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04);
+  box-sizing: border-box;
+}
+
+/* 2-column layout */
+.jt-single-product__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 36px;
+  align-items: start;
+}
+
+.jt-single-product__gallery-col,
+.jt-single-product__summary-col {
+  min-width: 0;
+}
+
+/* ========================================
+   GALLERY
+======================================== */
+
+.jt-single-product__gallery-frame {
+  position: relative;
+  background: #f8fafc;
+  border: 1px solid #d9e2ec;
+  border-radius: 18px;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+/* wishlist – čistá natívna ikonka pluginu */
+.jt-single-product__wishlist-float {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 5;
+  width: 28px;
+  height: 28px;
+  line-height: 1;
+}
+
+.jt-single-product__wishlist-float .yith-wcwl-add-to-wishlist,
+.jt-single-product__wishlist-float .yith-wcwl-add-button,
+.jt-single-product__wishlist-float .yith-wcwl-wishlistaddedbrowse,
+.jt-single-product__wishlist-float .yith-wcwl-wishlistexistsbrowse {
+  margin: 0 !important;
+  width: 28px;
+  height: 28px;
+}
+
+.jt-single-product__wishlist-float a {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 28px !important;
+  height: 28px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  text-decoration: none !important;
+  overflow: hidden;
+  transform: none !important;
+  transition: color 0.18s ease !important;
+}
+
+.jt-single-product__wishlist-float a:hover,
+.jt-single-product__wishlist-float a:focus-visible {
+  transform: none !important;
+  filter: none !important;
+  box-shadow: none !important;
+}
+
+.jt-single-product__wishlist-float a span:not(.yith-wcwl-icon),
+.jt-single-product__wishlist-float .feedback,
+.jt-single-product__wishlist-float .view-wishlist,
+.jt-single-product__wishlist-float .separator {
+  display: none !important;
+}
+
+.jt-single-product__wishlist-float i,
+.jt-single-product__wishlist-float .yith-wcwl-icon,
+.jt-single-product__wishlist-float svg {
+  display: inline-block !important;
+  width: 28px !important;
+  height: 28px !important;
+  line-height: 28px !important;
+  text-align: center !important;
+  font-size: 1.55rem !important;
+  color: var(--jt-primary-dark, #0f3b78) !important;
+  transition: color 0.18s ease !important;
+}
+
+/* pridané / existuje vo wishliste */
+.jt-single-product__wishlist-float .yith-wcwl-wishlistaddedbrowse i,
+.jt-single-product__wishlist-float .yith-wcwl-wishlistaddedbrowse .yith-wcwl-icon,
+.jt-single-product__wishlist-float .yith-wcwl-wishlistexistsbrowse i,
+.jt-single-product__wishlist-float .yith-wcwl-wishlistexistsbrowse .yith-wcwl-icon {
+  color: #ECC31F !important;
+}
+
+/* vypnúť floaty a default Woo layout */
+.jt-single-product__gallery-frame .woocommerce-product-gallery {
+  width: 100% !important;
+  float: none !important;
+  margin: 0 !important;
+}
+
+.jt-single-product__gallery-frame .woocommerce-product-gallery__wrapper,
+.jt-single-product__gallery-frame .woocommerce-product-gallery__image {
+  width: 100%;
+}
+
+.jt-single-product__gallery-frame .woocommerce-product-gallery__image {
+  margin: 0 !important;
+}
+
+.jt-single-product__gallery-frame .woocommerce-product-gallery__image a {
+  display: block;
+  width: 100%;
+}
+
+.jt-single-product__gallery-frame .woocommerce-product-gallery__image img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  object-position: center;
+  margin: 0 !important;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-sizing: border-box;
+}
+
+/* thumbnails */
+.jt-single-product__gallery-frame .flex-control-thumbs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin: 14px 0 0 !important;
+  padding: 0;
+  list-style: none;
+}
+
+.jt-single-product__gallery-frame .flex-control-thumbs li {
+  width: auto !important;
+  margin: 0 !important;
+}
+
+.jt-single-product__gallery-frame .flex-control-thumbs img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  padding: 6px;
+  background: #fff;
+  border: 1px solid #d9e2ec;
+  border-radius: 12px;
+  box-sizing: border-box;
+}
+
+/* sale badge zatiaľ preč */
+.jt-single-product__gallery-frame .onsale {
+  display: none !important;
+}
+
+/* ========================================
+   SUMMARY
+======================================== */
+
+.jt-single-product__summary-col {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.jt-single-product__title {
+  margin: 0 0 18px;
+  font-size: clamp(1.95rem, 2.9vw, 3.05rem);
+  line-height: 1.08;
+  font-weight: 800;
+  color: var(--jt-ink, #0f172a);
+  min-height: calc(1.08em * 3);
+}
+
+.jt-single-product__attributes-block {
+  margin: 0 0 16px;
+}
+
+.jt-single-product__attributes-list {
+  border-top: 1px solid var(--jt-line, #dbe3ee);
+}
+
+.jt-single-product__attribute-row {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr);
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--jt-line, #dbe3ee);
+}
+
+.jt-single-product__attribute-label {
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: var(--jt-ink, #0f172a);
+}
+
+.jt-single-product__attribute-row--categories .jt-single-product__attribute-label {
+  color: var(--jt-primary-dark, #0f3b78);
+}
+
+.jt-single-product__attribute-value,
+.jt-single-product__attribute-value p {
+  margin: 0;
+  font-size: 0.98rem;
+  color: var(--jt-ink, #0f172a);
+}
+
+.jt-single-product__attribute-value a {
+  color: #3095e8;
+  text-decoration: none;
+}
+
+.jt-single-product__attribute-value a:hover {
+  color: var(--jt-primary-dark, #0f3b78);
+  text-decoration: underline;
+}
+
+.jt-single-product__price {
+  margin: 0 0 8px;
+  font-size: 1.95rem;
+  line-height: 1.12;
+  font-weight: 700;
+}
+
+.jt-single-product__price,
+.jt-single-product__price .price,
+.jt-single-product__price .price span,
+.jt-single-product__price .price bdi {
+  color: #3095e8 !important;
+}
+
+.jt-single-product__stock {
+  margin: 0 0 16px;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.jt-single-product__stock .jt-stock-inline {
+  color: #16a34a !important;
+  font-weight: 500;
+}
+
+/* cart */
+.jt-single-product__cart {
+  margin: 0 0 12px;
+}
+
+.jt-single-product__cart form.cart {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0;
+}
+
+.jt-single-product__cart .quantity {
+  margin: 0 !important;
+}
+
+.jt-single-product__cart .qty {
+  min-height: 40px;
+  padding: 0 10px;
+  border: 1px solid var(--jt-line, #dbe3ee);
+  border-radius: 10px;
+}
+
+.jt-single-product__cart .single_add_to_cart_button,
+.jt-single-product__cart .button {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: auto !important;
+  min-width: 0;
+  height: 40px;
+  min-height: 40px;
+  padding: 0 18px !important;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #3095e8 0%, #194b9b 100%) !important;
+  color: #fff !important;
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none !important;
+  white-space: nowrap;
+  box-shadow: 0 2px 6px rgba(29, 78, 216, 0.12);
+  transition: filter 0.18s ease, opacity 0.18s ease;
+}
+
+.jt-single-product__cart .single_add_to_cart_button:hover,
+.jt-single-product__cart .single_add_to_cart_button:focus-visible,
+.jt-single-product__cart .button:hover,
+.jt-single-product__cart .button:focus-visible {
+  color: #fff !important;
+  filter: brightness(1.08);
+  opacity: 1;
+}
+
+.jt-single-product__description {
+  margin-top: 6px;
+  padding-top: 20px;
+  border-top: 1px solid var(--jt-line, #dbe3ee);
+}
+
+.jt-single-product__description-title {
+  margin: 0 0 12px;
+  font-size: 1.05rem;
+  line-height: 1.3;
+  font-weight: 700;
+  color: var(--jt-primary-dark, #0f3b78);
+}
+
+.jt-single-product__description-content {
+  color: var(--jt-ink, #0f172a);
+  line-height: 1.65;
+}
+
+/* ========================================
+   RELATED
+======================================== */
+
+.jt-single-product__related {
+  margin-top: -8px;  /* medzera medzi popisom a related produktami */
+}
+
+.jt-single-product__related-header {
+  margin-bottom: 20px;
+  padding-top: 12px;
+  border-top: 2px solid #3095e8;
+}
+
+.jt-single-product__related-title {
+  margin: 0;
+  font-size: 2rem;
+  line-height: 1.1;
+  font-weight: 800;
+  color: var(--jt-ink, #0f172a);
+}
+
+/* skryť default Woo nadpis */
+.jt-single-product__related .related > h2,
+.jt-single-product__related .products > h2 {
+  display: none;
+}
+
+/* related grid */
+.jt-single-product__related ul.products,
+.jt-single-product__related .woocommerce ul.products {
+  display: grid !important;
+  gap: 18px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.jt-single-product__related ul.products::before,
+.jt-single-product__related ul.products::after,
+.jt-single-product__related .woocommerce ul.products::before,
+.jt-single-product__related .woocommerce ul.products::after {
+  content: none !important;
+  display: none !important;
+}
+
+.jt-single-product__related ul.products li.product {
+  width: auto !important;
+  margin: 0 !important;
+  float: none !important;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.jt-single-product__related ul.products li.product img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  object-position: center;
+  margin: 0 0 12px !important;
+  padding: 10px;
+  background: #f8fafc;
+  border: 1px solid #d9e2ec;
+  border-radius: 14px;
+  box-sizing: border-box;
+}
+
+.jt-single-product__related ul.products li.product .woocommerce-loop-product__title {
+  margin: 0 0 10px !important;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  font-weight: 400;
+  color: var(--jt-ink, #0f172a) !important;
+  min-height: calc(1.35em * 3);
+}
+
+.jt-single-product__related ul.products li.product a.woocommerce-LoopProduct-link,
+.jt-single-product__related ul.products li.product a.woocommerce-loop-product__link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.jt-single-product__related ul.products li.product a.woocommerce-LoopProduct-link:hover .woocommerce-loop-product__title,
+.jt-single-product__related ul.products li.product a.woocommerce-loop-product__link:hover .woocommerce-loop-product__title {
+  color: var(--jt-primary-dark, #1e3a8a) !important;
+}
+
+.jt-single-product__related ul.products li.product .jt-product-card__price-stock {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  margin: 0 0 10px;
+  padding: 0 10px;
+  box-sizing: border-box;
+}
+
+.jt-single-product__related ul.products li.product .jt-product-card__price-stock .jt-stock-inline,
+.jt-single-product__related ul.products li.product .jt-stock-inline {
+  order: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 400;
+  line-height: 1.2;
+  color: #16a34a !important;
+  white-space: nowrap;
+}
+
+.jt-single-product__related ul.products li.product .jt-product-card__price-stock .price {
+  order: 2;
+  margin: 0 0 0 auto !important;
+  padding: 0 !important;
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1.2;
+  text-align: right;
+}
+
+.jt-single-product__related ul.products li.product .jt-product-card__price-stock .price,
+.jt-single-product__related ul.products li.product .jt-product-card__price-stock .price span,
+.jt-single-product__related ul.products li.product .jt-product-card__price-stock .price bdi {
+  color: #3095e8 !important;
+}
+
+/* schovať starý samotný price, nech sa nebije s wrapperom */
+.jt-single-product__related ul.products li.product > .price {
+  display: none;
+}
+
+.jt-single-product__related ul.products li.product .button,
+.jt-single-product__related ul.products li.product a.button,
+.jt-single-product__related ul.products li.product .add_to_cart_button,
+.jt-single-product__related ul.products li.product .ajax_add_to_cart {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  width: auto !important;
+  max-width: 100%;
+  height: 36px;
+  min-height: 36px;
+  margin-top: auto;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 14px !important;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #3095e8 0%, #194b9b 100%) !important;
+  color: #fff !important;
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none !important;
+  white-space: nowrap;
+  box-shadow: 0 2px 6px rgba(29, 78, 216, 0.12);
+  transition: filter 0.18s ease, opacity 0.18s ease;
+}
+
+.jt-single-product__related ul.products li.product .button:hover,
+.jt-single-product__related ul.products li.product a.button:hover,
+.jt-single-product__related ul.products li.product .add_to_cart_button:hover,
+.jt-single-product__related ul.products li.product .ajax_add_to_cart:hover {
+  color: #fff !important;
+  filter: brightness(1.08);
+  opacity: 1;
+}
+
+.jt-single-product__related ul.products li.product .added_to_cart {
+  display: none !important;
+}
+
+/* ========================================
+   RESPONSIVE
+======================================== */
+
+@media (max-width: 1200px) {
+  .jt-single-product__related ul.products,
+  .jt-single-product__related .woocommerce ul.products {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .jt-single-product__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .jt-single-product__title {
+    min-height: 0;
+  }
+
+  .jt-single-product__related ul.products,
+  .jt-single-product__related .woocommerce ul.products {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .single-product {
+    --jt-single-gap: 20px;
+  }
+
+  .single-product-page {
+    padding: 20px 0 24px;
+  }
+
+  .jt-single-product__card {
+    padding: 20px 16px 24px;
+    border-radius: 18px;
+  }
+
+  .jt-single-product__title {
+    font-size: 2rem;
+    min-height: 0;
+  }
+
+  .jt-single-product__attribute-row {
+    grid-template-columns: 110px minmax(0, 1fr);
+    gap: 12px;
+    padding: 10px 0;
+  }
+
+  .jt-single-product__cart form.cart {
+    flex-wrap: wrap;
+  }
+
+  .jt-single-product__cart .single_add_to_cart_button,
+  .jt-single-product__cart .button {
+    width: 100% !important;
+  }
+
+  .jt-single-product__wishlist-float {
+    top: 12px;
+    right: 12px;
+    width: 26px;
+    height: 26px;
+  }
+
+  .jt-single-product__wishlist-float .yith-wcwl-add-to-wishlist,
+  .jt-single-product__wishlist-float .yith-wcwl-add-button,
+  .jt-single-product__wishlist-float .yith-wcwl-wishlistaddedbrowse,
+  .jt-single-product__wishlist-float .yith-wcwl-wishlistexistsbrowse,
+  .jt-single-product__wishlist-float a,
+  .jt-single-product__wishlist-float i,
+  .jt-single-product__wishlist-float .yith-wcwl-icon,
+  .jt-single-product__wishlist-float svg {
+    width: 26px !important;
+    height: 26px !important;
+    line-height: 26px !important;
+  }
+
+  .jt-single-product__wishlist-float i,
+  .jt-single-product__wishlist-float .yith-wcwl-icon,
+  .jt-single-product__wishlist-float svg {
+    font-size: 1.4rem !important;
+  }
+
+  .jt-single-product__related ul.products,
+  .jt-single-product__related .woocommerce ul.products {
+    gap: 12px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .jt-single-product__related ul.products li.product .woocommerce-loop-product__title {
+    min-height: 0;
+  }
+
+  .jt-single-product__related ul.products li.product .jt-product-card__price-stock {
+    gap: 8px;
+  }
+
+  .jt-single-product__related ul.products li.product .jt-stock-inline {
+    font-size: 0.84rem;
+  }
+}

--- a/assets/js/filter-accordion.js
+++ b/assets/js/filter-accordion.js
@@ -40,6 +40,19 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
+  function hasActiveSelection(filter) {
+    return !!filter.querySelector(
+      'input[type="checkbox"]:checked,' +
+      'input[type="radio"]:checked,' +
+      'option:checked,' +
+      'li.chosen,' +
+      '.chosen,' +
+      '.active,' +
+      '.selected,' +
+      '[aria-current="true"]'
+    );
+  }
+
   function prepareAccordions() {
     const filters = filterBox.querySelectorAll('.yith-wcan-filter');
 
@@ -59,6 +72,7 @@ document.addEventListener('DOMContentLoaded', function () {
       }
 
       const key = getFilterKey(title);
+      const isActiveFilter = hasActiveSelection(filter);
 
       filter.classList.add('jt-filter-accordion');
       title.classList.add('jt-filter-accordion__trigger');
@@ -73,8 +87,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
       title.setAttribute('aria-controls', content.id);
 
-      // default len pri prvom stretnutí s filtrom
-      if (!accordionState.has(key)) {
+      /**
+       * Priorita:
+       * 1. aktívny filter = vždy otvorený
+       * 2. uložený stav
+       * 3. defaultne iba prvý filter
+       */
+      if (isActiveFilter) {
+        accordionState.set(key, true);
+      } else if (!accordionState.has(key)) {
         accordionState.set(key, index === 0);
       }
 

--- a/assets/js/filter-force-reload.js
+++ b/assets/js/filter-force-reload.js
@@ -21,6 +21,30 @@ document.addEventListener('DOMContentLoaded', function () {
     }, 500);
   }
 
+  function isArchiveLikePage() {
+    const body = document.body;
+
+    return (
+      body.classList.contains('post-type-archive-product') ||
+      body.classList.contains('tax-product_cat') ||
+      body.classList.contains('tax-product_tag') ||
+      body.classList.contains('tax-pa_tim') ||
+      body.classList.contains('tax-pa_sezona') ||
+      body.classList.contains('tax-pa_kolekcia') ||
+      body.classList.contains('tax-pa_subset') ||
+      body.classList.contains('tax-pa_vyrobca') ||
+      body.classList.contains('tax-pa_gradovana') ||
+      window.location.pathname.includes('/product-category/') ||
+      window.location.pathname.includes('/product-tag/') ||
+      window.location.pathname.includes('/attribute/') ||
+      window.location.search.includes('filter_') ||
+      target !== null
+    );
+  }
+
+  /**
+   * Kliky vo filtroch / quick links
+   */
   filterAreas.forEach(function (area) {
     area.addEventListener('change', function (event) {
       const input = event.target.closest('input[type="checkbox"], input[type="radio"], select');
@@ -41,6 +65,45 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 
+  /**
+   * Kliky zo single produktu na kategórie / atribúty
+   */
+  document.addEventListener('click', function (event) {
+    const taxonomyLink = event.target.closest(
+      '.jt-single-product__attribute-value a, .jt-single-product__attribute-row--categories a'
+    );
+
+    if (!taxonomyLink) return;
+
+    sessionStorage.setItem('jt-scroll-after-filter', '1');
+    sessionStorage.setItem('jt-force-archive-reload', '1');
+    sessionStorage.removeItem('jt-force-archive-reload-done');
+  });
+
+  /**
+   * Po príchode na archive/tax stránku spraviť ešte jeden refresh
+   */
+  const shouldForceReload = sessionStorage.getItem('jt-force-archive-reload') === '1';
+  const reloadDone = sessionStorage.getItem('jt-force-archive-reload-done') === '1';
+
+  if (shouldForceReload && isArchiveLikePage() && !reloadDone) {
+    sessionStorage.setItem('jt-force-archive-reload-done', '1');
+
+    setTimeout(function () {
+      window.location.reload();
+    }, 60);
+
+    return;
+  }
+
+  if (reloadDone && isArchiveLikePage()) {
+    sessionStorage.removeItem('jt-force-archive-reload');
+    sessionStorage.removeItem('jt-force-archive-reload-done');
+  }
+
+  /**
+   * Scroll po refreshe / filtrovaní
+   */
   const shouldScroll = sessionStorage.getItem('jt-scroll-after-filter') === '1';
 
   if (shouldScroll && target) {

--- a/functions.php
+++ b/functions.php
@@ -31,7 +31,7 @@ function jtcollector_theme_setup(): void
 	// WooCommerce support
 	add_theme_support('woocommerce');
 
-	// MENU LOCATIONS
+	// Menu locations
 	register_nav_menus([
 		'header_about_menu' => __('Header About Menu', 'jtcollector'),
 		'header_info_menu'  => __('Header Info Menu', 'jtcollector'),
@@ -41,20 +41,39 @@ function jtcollector_theme_setup(): void
 }
 add_action('after_setup_theme', 'jtcollector_theme_setup');
 
+/**
+ * Helper: asset version by filemtime
+ */
+function jtcollector_asset_version(string $relative_path): string
+{
+	$absolute_path = get_template_directory() . $relative_path;
+
+	if (file_exists($absolute_path)) {
+		return (string) filemtime($absolute_path);
+	}
+
+	return wp_get_theme()->get('Version');
+}
+
+/**
+ * Helper: archive-like Woo pages where filters are used
+ */
+function jtcollector_is_filter_archive(): bool
+{
+	return is_shop() || is_product_taxonomy();
+}
 
 /**
  * Enqueue theme assets
  */
 function jtcollector_enqueue_assets(): void
 {
-	$theme_version = wp_get_theme()->get('Version');
-
 	// MAIN STYLE
 	wp_enqueue_style(
 		'jtcollector-main-style',
 		get_template_directory_uri() . '/assets/css/main.css',
 		[],
-		$theme_version
+		jtcollector_asset_version('/assets/css/main.css')
 	);
 
 	// HEADER STYLE
@@ -62,31 +81,15 @@ function jtcollector_enqueue_assets(): void
 		'jtcollector-header-style',
 		get_template_directory_uri() . '/assets/css/header.css',
 		['jtcollector-main-style'],
-		filemtime(get_template_directory() . '/assets/css/header.css')
+		jtcollector_asset_version('/assets/css/header.css')
 	);
 
 	// FOOTER STYLE
 	wp_enqueue_style(
-		'jt-footer-style',
+		'jtcollector-footer-style',
 		get_template_directory_uri() . '/assets/css/footer.css',
-		[],
-		filemtime(get_template_directory() . '/assets/css/footer.css')
-	);
-
-	// HOME FEATURED PRODUCTS STYLE
-	wp_enqueue_style(
-		'jtcollector-home-featured-products',
-		get_template_directory_uri() . '/assets/css/home-featured-products.css',
 		['jtcollector-main-style'],
-		filemtime(get_template_directory() . '/assets/css/home-featured-products.css')
-	);
-
-	// WOOCOMMERCE STYLE
-	wp_enqueue_style(
-		'jtcollector-woocommerce',
-		get_template_directory_uri() . '/assets/css/woocommerce.css',
-		['jtcollector-main-style'],
-		filemtime(get_template_directory() . '/assets/css/woocommerce.css')
+		jtcollector_asset_version('/assets/css/footer.css')
 	);
 
 	// PAGE CONTENT STYLE
@@ -94,32 +97,78 @@ function jtcollector_enqueue_assets(): void
 		'jtcollector-page-content',
 		get_template_directory_uri() . '/assets/css/page-content.css',
 		['jtcollector-main-style'],
-		filemtime(get_template_directory() . '/assets/css/page-content.css')
+		jtcollector_asset_version('/assets/css/page-content.css')
 	);
 
-	// HEADER SCRIPT (prepínanie panelov)
-	wp_enqueue_script(
-		'jtcollector-header-script',
-		get_template_directory_uri() . '/assets/js/header.js',
-		[],
-		filemtime(get_template_directory() . '/assets/js/header.js'),
-		true
+	// HOME FEATURED PRODUCTS STYLE
+	wp_enqueue_style(
+		'jtcollector-home-featured-products',
+		get_template_directory_uri() . '/assets/css/home-featured-products.css',
+		['jtcollector-main-style'],
+		jtcollector_asset_version('/assets/css/home-featured-products.css')
 	);
 
 	// HOME BLOG STYLE
 	wp_enqueue_style(
-	'jtcollector-home-blog',
-	get_template_directory_uri() . '/assets/css/home-blog.css',
-	[],
-	wp_get_theme()->get('Version')
-);
+		'jtcollector-home-blog',
+		get_template_directory_uri() . '/assets/css/home-blog.css',
+		['jtcollector-main-style'],
+		jtcollector_asset_version('/assets/css/home-blog.css')
+	);
+
+	// WOOCOMMERCE ARCHIVE STYLE
+	wp_enqueue_style(
+		'jtcollector-woocommerce',
+		get_template_directory_uri() . '/assets/css/woocommerce.css',
+		['jtcollector-main-style'],
+		jtcollector_asset_version('/assets/css/woocommerce.css')
+	);
+
+	// SINGLE PRODUCT STYLE – len na detaile produktu
+	if (is_product()) {
+		wp_enqueue_style(
+			'jtcollector-single-product',
+			get_template_directory_uri() . '/assets/css/single-product.css',
+			['jtcollector-main-style', 'jtcollector-woocommerce'],
+			jtcollector_asset_version('/assets/css/single-product.css')
+		);
+	}
+
+	// HEADER SCRIPT
+	wp_enqueue_script(
+		'jtcollector-header-script',
+		get_template_directory_uri() . '/assets/js/header.js',
+		[],
+		jtcollector_asset_version('/assets/js/header.js'),
+		true
+	);
+
+	// FILTER SCRIPTS – shop + všetky Woo taxonómie
+	if (jtcollector_is_filter_archive()) {
+		wp_enqueue_script(
+			'jt-filter-accordion',
+			get_template_directory_uri() . '/assets/js/filter-accordion.js',
+			[],
+			jtcollector_asset_version('/assets/js/filter-accordion.js'),
+			true
+		);
+
+		wp_enqueue_script(
+			'jt-filter-force-reload',
+			get_template_directory_uri() . '/assets/js/filter-force-reload.js',
+			[],
+			jtcollector_asset_version('/assets/js/filter-force-reload.js'),
+			true
+		);
+	}
 }
 add_action('wp_enqueue_scripts', 'jtcollector_enqueue_assets');
 
 /**
  * AJAX refresh header cart contents
  */
-function jtcollector_header_cart_fragment($fragments) {
+function jtcollector_header_cart_fragment($fragments)
+{
 	ob_start();
 	?>
 	<span class="site-header__cart-text js-header-cart-text">
@@ -131,35 +180,98 @@ function jtcollector_header_cart_fragment($fragments) {
 
 	return $fragments;
 }
-
-/**
- * Enqueue filter accordion script on shop and product archive pages
- */	
-add_action('wp_enqueue_scripts', function () {
-	if (is_shop() || is_product_category() || is_product_tag()) {
-		wp_enqueue_script(
-		'jt-filter-accordion',
-		get_template_directory_uri() . '/assets/js/filter-accordion.js',
-		[],
-		'1.0.2',
-		true
-		);  
-	}
-});
-
-/**
- * Enqueue filter force reload script on shop and product archive pages
- */
-add_action('wp_enqueue_scripts', function () {
-	if (is_shop() || is_product_taxonomy() || is_product_tag()) {
-		wp_enqueue_script(
-			'jt-filter-force-reload',
-			get_template_directory_uri() . '/assets/js/filter-force-reload.js',
-			[],
-			'1.0.0',
-			true
-		);
-	}
-});
-
 add_filter('woocommerce_add_to_cart_fragments', 'jtcollector_header_cart_fragment');
+
+/**
+ * SINGLE PRODUCT – cleanup
+ */
+function jtcollector_single_product_cleanup(): void
+{
+	// Tabs nechceme
+	remove_action('woocommerce_after_single_product_summary', 'woocommerce_output_product_data_tabs', 10);
+
+	// Meta si zobrazujeme manuálne
+	remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_meta', 40);
+
+	// Default related products vypneme, zobrazujeme ich manuálne v šablóne
+	remove_action('woocommerce_after_single_product_summary', 'woocommerce_output_related_products', 20);
+}
+add_action('wp', 'jtcollector_single_product_cleanup');
+
+/**
+ * SINGLE PRODUCT – schovať default stock text pri add to cart,
+ * aby sa nezobrazoval dvakrát.
+ */
+function jtcollector_hide_single_product_stock_html($html, $product)
+{
+	if (is_product()) {
+		return '';
+	}
+
+	return $html;
+}
+add_filter('woocommerce_get_stock_html', 'jtcollector_hide_single_product_stock_html', 10, 2);
+
+/**
+ * RELATED PRODUCTS NA SINGLE – sklad + cena v jednom riadku
+ */
+if (!function_exists('jtcollector_single_related_price_stock_wrap_open')) {
+	function jtcollector_single_related_price_stock_wrap_open()
+	{
+		if (!is_product()) {
+			return;
+		}
+
+		echo '<div class="jt-product-card__price-stock">';
+	}
+}
+
+if (!function_exists('jtcollector_single_related_product_stock_inline')) {
+	function jtcollector_single_related_product_stock_inline()
+	{
+		if (!is_product()) {
+			return;
+		}
+
+		global $product;
+
+		if (!$product || !is_a($product, 'WC_Product')) {
+			return;
+		}
+
+		$stock_quantity = $product->get_stock_quantity();
+
+		if ($product->managing_stock() && $stock_quantity !== null && $stock_quantity > 0) {
+			echo '<span class="jt-stock-inline">Skladom ' . esc_html($stock_quantity) . ' ks</span>';
+		}
+	}
+}
+
+if (!function_exists('jtcollector_single_related_price_stock_wrap_close')) {
+	function jtcollector_single_related_price_stock_wrap_close()
+	{
+		if (!is_product()) {
+			return;
+		}
+
+		echo '</div>';
+	}
+}
+
+/**
+ * SINGLE PRODUCT – prepnúť related products price output
+ */
+function jtcollector_single_related_products_hooks(): void
+{
+	if (!is_product()) {
+		return;
+	}
+
+	remove_action('woocommerce_after_shop_loop_item_title', 'woocommerce_template_loop_price', 10);
+
+	add_action('woocommerce_after_shop_loop_item_title', 'jtcollector_single_related_price_stock_wrap_open', 9);
+	add_action('woocommerce_after_shop_loop_item_title', 'jtcollector_single_related_product_stock_inline', 10);
+	add_action('woocommerce_after_shop_loop_item_title', 'woocommerce_template_loop_price', 11);
+	add_action('woocommerce_after_shop_loop_item_title', 'jtcollector_single_related_price_stock_wrap_close', 12);
+}
+add_action('wp', 'jtcollector_single_related_products_hooks');

--- a/woocommerce/single-product.php
+++ b/woocommerce/single-product.php
@@ -1,0 +1,155 @@
+<?php
+defined('ABSPATH') || exit;
+
+get_header();
+?>
+
+<main class="site-main single-product-page">
+	<div class="site-container">
+
+		<?php while (have_posts()) : the_post(); ?>
+			<?php global $product; ?>
+
+			<div id="product-<?php the_ID(); ?>" <?php wc_product_class('jt-single-product', $product); ?>>
+
+				<div class="jt-single-product__card">
+					<div class="jt-single-product__layout">
+
+						<!-- ĽAVÝ STĹPEC: GALÉRIA -->
+						<div class="jt-single-product__gallery-col">
+							<div class="jt-single-product__gallery-frame">
+
+								<div class="jt-single-product__wishlist-float" aria-label="Pridať do obľúbených">
+									<?php echo do_shortcode('[yith_wcwl_add_to_wishlist]'); ?>
+								</div>
+
+								<?php do_action('woocommerce_before_single_product_summary'); ?>
+							</div>
+						</div>
+
+						<!-- PRAVÝ STĹPEC: INFO -->
+						<div class="jt-single-product__summary-col">
+
+							<h1 class="jt-single-product__title"><?php the_title(); ?></h1>
+
+							<?php
+							$attributes = $product ? $product->get_attributes() : [];
+							$categories = wc_get_product_category_list($product->get_id(), ', ');
+							?>
+
+							<div class="jt-single-product__attributes-block">
+								<div class="jt-single-product__attributes-list">
+
+									<?php if (!empty($categories)) : ?>
+										<div class="jt-single-product__attribute-row jt-single-product__attribute-row--categories">
+											<div class="jt-single-product__attribute-label">Kategórie</div>
+											<div class="jt-single-product__attribute-value">
+												<?php echo wp_kses_post($categories); ?>
+											</div>
+										</div>
+									<?php endif; ?>
+
+									<?php if (!empty($attributes)) : ?>
+										<?php foreach ($attributes as $attribute_key => $attribute) : ?>
+											<?php
+											if (!$attribute) {
+												continue;
+											}
+
+											$label = wc_attribute_label($attribute->get_name());
+
+											if ($attribute->is_taxonomy()) {
+												$terms  = wc_get_product_terms($product->get_id(), $attribute->get_name(), ['fields' => 'all']);
+												$values = [];
+
+												if (!empty($terms) && !is_wp_error($terms)) {
+													foreach ($terms as $term) {
+														$link = get_term_link($term);
+
+														if (!is_wp_error($link)) {
+															$values[] = '<a href="' . esc_url($link) . '">' . esc_html($term->name) . '</a>';
+														} else {
+															$values[] = esc_html($term->name);
+														}
+													}
+												}
+
+												$value_output = implode(', ', $values);
+											} else {
+												$options      = $attribute->get_options();
+												$values       = array_map('esc_html', $options);
+												$value_output = implode(', ', $values);
+											}
+
+											if (empty($value_output)) {
+												continue;
+											}
+											?>
+											<div class="jt-single-product__attribute-row">
+												<div class="jt-single-product__attribute-label"><?php echo esc_html($label); ?></div>
+												<div class="jt-single-product__attribute-value"><?php echo wp_kses_post($value_output); ?></div>
+											</div>
+										<?php endforeach; ?>
+									<?php endif; ?>
+
+								</div>
+							</div>
+
+							<div class="jt-single-product__price">
+								<?php echo $product->get_price_html(); ?>
+							</div>
+
+							<div class="jt-single-product__stock">
+								<?php
+								if ($product->managing_stock()) {
+									$qty = $product->get_stock_quantity();
+
+									if ($qty !== null && $qty > 0) {
+										echo '<span class="jt-stock-inline">Skladom ' . esc_html($qty) . ' ks</span>';
+									}
+								} elseif ($product->is_in_stock()) {
+									echo '<span class="jt-stock-inline">Skladom</span>';
+								}
+								?>
+							</div>
+
+							<div class="jt-single-product__cart">
+								<?php woocommerce_template_single_add_to_cart(); ?>
+							</div>
+
+							<?php
+							$content = trim(get_the_content());
+							if (!empty($content)) :
+							?>
+								<div class="jt-single-product__description">
+									<h2 class="jt-single-product__description-title">Popis</h2>
+									<div class="jt-single-product__description-content">
+										<?php the_content(); ?>
+									</div>
+								</div>
+							<?php endif; ?>
+
+						</div>
+					</div>
+
+					<div class="jt-single-product__related">
+						<div class="jt-single-product__related-header">
+							<h2 class="jt-single-product__related-title">Súvisiace produkty</h2>
+						</div>
+
+						<?php
+						woocommerce_related_products([
+							'posts_per_page' => 6,
+							'columns'        => 6,
+						]);
+						?>
+					</div>
+				</div>
+
+			</div>
+		<?php endwhile; ?>
+
+	</div>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Popis
Táto vetva prináša dokončenie vlastnej šablóny detailu produktu a zároveň doladenie accordion filtrov pri prechode z detailu produktu na archív atribútu alebo kategórie.

## Hotové zmeny
- vytvorený vlastný single product layout v štýle JTCollector
- obrázok produktu zobrazený vo vlastnom boxe
- informácie o produkte upravené do prehľadnej tabuľky atribútov
- kategórie presunuté ako prvý riadok tabuľky
- wishlist ikona presunutá do pravého horného rohu boxu s fotkou
- zvýraznená cena, sklad a CTA tlačidlo zjednotené s dizajnom webu
- súvisiace produkty vložené do hlavného boxu pod modrú oddeľovaciu čiaru
- pri related produktoch doplnený počet kusov skladom
- filter accordion po prechode z detailu produktu správne ostáva otvorený na aktívnom filtri
- aktívna hodnota vo filtri ostáva po refreshi viditeľná a zaškrtnutá

## Technické zmeny
- `single-product.php`
- `single-product.css`
- `functions.php`
- `filter-accordion.js`
- `filter-force-reload.js`

## Výsledok
Detail produktu je teraz vizuálne zjednotený so zvyškom webu a prechod z atribútov produktu na archív funguje prirodzene aj s aktívnym accordion filtrom.