### PR TITLE
62 feature/wishlist star in archive product and feature products

### DIFF
--- a/assets/css/home-featured-products.css
+++ b/assets/css/home-featured-products.css
@@ -120,6 +120,87 @@
   min-width: 0;
 }
 
+/* image wrapper */
+.jt-home-product__image-wrap {
+  position: relative;
+  display: block;
+  width: 100%;
+  margin: 0 0 12px;
+  padding: 10px;
+  background: #f8fafc;
+  border: 1px solid #d9e2ec;
+  border-radius: 14px;
+  box-sizing: border-box;
+}
+
+/* wishlist v rohu obrázka */
+.jt-home-product__wishlist {
+  position: absolute;
+  top: -1px;
+  right: 6px;
+  z-index: 3;
+  width: 22px;
+  height: 22px;
+  line-height: 1;
+}
+
+/* wrappery pluginu */
+.jt-home-product__wishlist .yith-wcwl-add-to-wishlist,
+.jt-home-product__wishlist .yith-wcwl-add-button,
+.jt-home-product__wishlist .yith-wcwl-wishlistaddedbrowse,
+.jt-home-product__wishlist .yith-wcwl-wishlistexistsbrowse {
+  margin: 0 !important;
+  width: 22px;
+  height: 22px;
+}
+
+/* link */
+.jt-home-product__wishlist a {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 22px !important;
+  height: 22px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  text-decoration: none !important;
+  overflow: hidden;
+  transform: none !important;
+  transition: none !important;
+}
+
+/* hover bez efektov od pluginu */
+.jt-home-product__wishlist a:hover,
+.jt-home-product__wishlist a:focus-visible {
+  transform: none !important;
+  filter: none !important;
+  box-shadow: none !important;
+}
+
+/* skryť texty */
+.jt-home-product__wishlist a span:not(.yith-wcwl-icon),
+.jt-home-product__wishlist .feedback,
+.jt-home-product__wishlist .view-wishlist,
+.jt-home-product__wishlist .separator {
+  display: none !important;
+}
+
+/* ikona – veľkosť áno, farby riadi plugin */
+.jt-home-product__wishlist i,
+.jt-home-product__wishlist .yith-wcwl-icon,
+.jt-home-product__wishlist svg {
+  display: inline-block !important;
+  width: 22px !important;
+  height: 22px !important;
+  line-height: 22px !important;
+  text-align: center !important;
+  font-size: 1.15rem !important;
+  transition: none !important;
+}
+
 /* obrázok */
 .shop-home-entry ul.products li.product img {
   display: block;
@@ -127,11 +208,11 @@
   aspect-ratio: 1 / 1;
   object-fit: contain;
   object-position: center;
-  margin: 0 0 12px;
-  padding: 10px;
-  background: #f8fafc;
-  border: 1px solid #d9e2ec;
-  border-radius: 14px;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
   box-sizing: border-box;
 }
 
@@ -311,5 +392,31 @@
 
   .shop-home-entry ul.products li.product .jt-home-product__price-row {
     gap: 8px;
+  }
+
+  .jt-home-product__wishlist {
+    top: 7px;
+    right: 7px;
+    width: 20px;
+    height: 20px;
+  }
+
+  .jt-home-product__wishlist .yith-wcwl-add-to-wishlist,
+  .jt-home-product__wishlist .yith-wcwl-add-button,
+  .jt-home-product__wishlist .yith-wcwl-wishlistaddedbrowse,
+  .jt-home-product__wishlist .yith-wcwl-wishlistexistsbrowse,
+  .jt-home-product__wishlist a,
+  .jt-home-product__wishlist i,
+  .jt-home-product__wishlist .yith-wcwl-icon,
+  .jt-home-product__wishlist svg {
+    width: 20px !important;
+    height: 20px !important;
+    line-height: 20px !important;
+  }
+
+  .jt-home-product__wishlist i,
+  .jt-home-product__wishlist .yith-wcwl-icon,
+  .jt-home-product__wishlist svg {
+    font-size: 1.02rem !important;
   }
 }

--- a/assets/css/single-product.css
+++ b/assets/css/single-product.css
@@ -59,7 +59,7 @@
 /* wishlist – čistá natívna ikonka pluginu */
 .jt-single-product__wishlist-float {
   position: absolute;
-  top: 14px;
+  top: 8px;
   right: 14px;
   z-index: 5;
   width: 28px;
@@ -90,7 +90,7 @@
   text-decoration: none !important;
   overflow: hidden;
   transform: none !important;
-  transition: color 0.18s ease !important;
+  transition: none !important;
 }
 
 .jt-single-product__wishlist-float a:hover,
@@ -107,6 +107,7 @@
   display: none !important;
 }
 
+/* ikona – veľkosť áno, farbu riadi plugin */
 .jt-single-product__wishlist-float i,
 .jt-single-product__wishlist-float .yith-wcwl-icon,
 .jt-single-product__wishlist-float svg {
@@ -116,16 +117,7 @@
   line-height: 28px !important;
   text-align: center !important;
   font-size: 1.55rem !important;
-  color: var(--jt-primary-dark, #0f3b78) !important;
-  transition: color 0.18s ease !important;
-}
-
-/* pridané / existuje vo wishliste */
-.jt-single-product__wishlist-float .yith-wcwl-wishlistaddedbrowse i,
-.jt-single-product__wishlist-float .yith-wcwl-wishlistaddedbrowse .yith-wcwl-icon,
-.jt-single-product__wishlist-float .yith-wcwl-wishlistexistsbrowse i,
-.jt-single-product__wishlist-float .yith-wcwl-wishlistexistsbrowse .yith-wcwl-icon {
-  color: #ECC31F !important;
+  transition: none !important;
 }
 
 /* vypnúť floaty a default Woo layout */

--- a/assets/css/single-product.css
+++ b/assets/css/single-product.css
@@ -59,7 +59,7 @@
 /* wishlist – čistá natívna ikonka pluginu */
 .jt-single-product__wishlist-float {
   position: absolute;
-  top: 8px;
+  top: 6px;
   right: 14px;
   z-index: 5;
   width: 28px;

--- a/assets/css/woocommerce.css
+++ b/assets/css/woocommerce.css
@@ -498,6 +498,108 @@
   box-sizing: border-box;
 }
 
+/* ========================================
+   ARCHIVE PRODUCT CARD – image wrapper + wishlist
+======================================== */
+
+.woocommerce ul.products li.product .jt-archive-product__image-wrap {
+  position: relative;
+  width: 100%;
+  margin: 0 0 12px;
+  padding: 10px;
+  background: #f8fafc;
+  border: 1px solid #d9e2ec;
+  border-radius: 14px;
+  box-sizing: border-box;
+}
+
+.woocommerce ul.products li.product .jt-archive-product__image-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.woocommerce ul.products li.product .jt-archive-product__image-link img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  object-position: center;
+  margin: 0 !important;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-sizing: border-box;
+}
+
+/* wishlist v pravom hornom rohu frame */
+.woocommerce ul.products li.product .jt-archive-product__wishlist {
+  position: absolute;
+  top: -1px;
+  right: 5px;
+  z-index: 3;
+  width: 22px;
+  height: 22px;
+  line-height: 1;
+}
+
+/* wrappery pluginu */
+.woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-add-to-wishlist,
+.woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-add-button,
+.woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-wishlistaddedbrowse,
+.woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-wishlistexistsbrowse {
+  margin: 0 !important;
+  width: 22px;
+  height: 22px;
+}
+
+/* link */
+.woocommerce ul.products li.product .jt-archive-product__wishlist a {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 20px !important;
+  height: 20px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  text-decoration: none !important;
+  overflow: hidden;
+  transform: none !important;
+  transition: none !important;
+}
+
+.woocommerce ul.products li.product .jt-archive-product__wishlist a:hover,
+.woocommerce ul.products li.product .jt-archive-product__wishlist a:focus-visible {
+  transform: none !important;
+  filter: none !important;
+  box-shadow: none !important;
+}
+
+/* skryť texty */
+.woocommerce ul.products li.product .jt-archive-product__wishlist a span:not(.yith-wcwl-icon),
+.woocommerce ul.products li.product .jt-archive-product__wishlist .feedback,
+.woocommerce ul.products li.product .jt-archive-product__wishlist .view-wishlist,
+.woocommerce ul.products li.product .jt-archive-product__wishlist .separator {
+  display: none !important;
+}
+
+/* ikona – veľkosť áno, farby riadi plugin */
+.woocommerce ul.products li.product .jt-archive-product__wishlist i,
+.woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-icon,
+.woocommerce ul.products li.product .jt-archive-product__wishlist svg {
+  display: inline-block !important;
+  width: 22px !important;
+  height: 22px !important;
+  line-height: 22px !important;
+  text-align: center !important;
+  font-size: 1.15rem !important;
+  transition: none !important;
+}
+
 /* TITLE */
 .woocommerce ul.products li.product .woocommerce-loop-product__title {
   display: block;
@@ -792,5 +894,31 @@
 
   .shop-price-filter-box .price_slider_amount {
     align-items: flex-start;
+  }
+
+  .woocommerce ul.products li.product .jt-archive-product__wishlist {
+    top: 7px;
+    right: 7px;
+    width: 20px;
+    height: 20px;
+  }
+
+  .woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-add-to-wishlist,
+  .woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-add-button,
+  .woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-wishlistaddedbrowse,
+  .woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-wishlistexistsbrowse,
+  .woocommerce ul.products li.product .jt-archive-product__wishlist a,
+  .woocommerce ul.products li.product .jt-archive-product__wishlist i,
+  .woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-icon,
+  .woocommerce ul.products li.product .jt-archive-product__wishlist svg {
+    width: 20px !important;
+    height: 20px !important;
+    line-height: 20px !important;
+  }
+
+  .woocommerce ul.products li.product .jt-archive-product__wishlist i,
+  .woocommerce ul.products li.product .jt-archive-product__wishlist .yith-wcwl-icon,
+  .woocommerce ul.products li.product .jt-archive-product__wishlist svg {
+    font-size: 1.02rem !important;
   }
 }

--- a/template-parts/home-featured-products.php
+++ b/template-parts/home-featured-products.php
@@ -56,11 +56,18 @@ $featured_query = new WP_Query($featured_args);
               <li <?php wc_product_class('', $product); ?>>
 
                 <a href="<?php the_permalink(); ?>" class="woocommerce-LoopProduct-link woocommerce-loop-product__link">
-                  <?php
-                  if (has_post_thumbnail()) {
-                    echo woocommerce_get_product_thumbnail();
-                  }
-                  ?>
+                  <div class="jt-home-product__image-wrap">
+                    <div class="jt-home-product__wishlist" aria-label="Pridať do obľúbených">
+                      <?php echo do_shortcode('[yith_wcwl_add_to_wishlist]'); ?>
+                    </div>
+
+                    <?php
+                    if (has_post_thumbnail()) {
+                      echo woocommerce_get_product_thumbnail();
+                    }
+                    ?>
+                  </div>
+
                   <h3 class="woocommerce-loop-product__title"><?php the_title(); ?></h3>
                 </a>
 

--- a/woocommerce/archive-product.php
+++ b/woocommerce/archive-product.php
@@ -47,6 +47,45 @@ if (!function_exists('jtcollector_archive_price_stock_wrap_close')) {
 	}
 }
 
+/**
+ * Vlastný obrázkový wrapper pre archív produktu + wishlist.
+ */
+if (!function_exists('jtcollector_archive_product_image_with_wishlist')) {
+	function jtcollector_archive_product_image_with_wishlist() {
+		global $product;
+
+		if (!$product || !is_a($product, 'WC_Product')) {
+			return;
+		}
+
+		echo '<div class="jt-archive-product__image-wrap">';
+
+		echo '<div class="jt-archive-product__wishlist" aria-label="Pridať do obľúbených">';
+		echo do_shortcode('[yith_wcwl_add_to_wishlist]');
+		echo '</div>';
+
+		echo '<a href="' . esc_url(get_permalink()) . '" class="jt-archive-product__image-link woocommerce-LoopProduct-link woocommerce-loop-product__link">';
+
+		if (has_post_thumbnail()) {
+			echo woocommerce_get_product_thumbnail();
+		}
+
+		echo '</a>';
+		echo '</div>';
+	}
+}
+
+/**
+ * Vlastný názov produktu ako samostatný link.
+ */
+if (!function_exists('jtcollector_archive_product_title_link')) {
+	function jtcollector_archive_product_title_link() {
+		echo '<a href="' . esc_url(get_permalink()) . '" class="jt-archive-product__title-link woocommerce-LoopProduct-link woocommerce-loop-product__link">';
+		echo '<h2 class="woocommerce-loop-product__title">' . get_the_title() . '</h2>';
+		echo '</a>';
+	}
+}
+
 /*
  * Default WooCommerce:
  * woocommerce_template_loop_price = priority 10
@@ -62,6 +101,22 @@ add_action('woocommerce_after_shop_loop_item_title', 'jtcollector_archive_price_
 add_action('woocommerce_after_shop_loop_item_title', 'jtcollector_archive_product_stock_inline', 10);
 add_action('woocommerce_after_shop_loop_item_title', 'woocommerce_template_loop_price', 11);
 add_action('woocommerce_after_shop_loop_item_title', 'jtcollector_archive_price_stock_wrap_close', 12);
+
+/*
+ * Vlastná produktová karta pre archív:
+ * - zrušíme default link
+ * - zrušíme default thumbnail
+ * - zrušíme default title
+ * - vložíme vlastný image wrapper s wishlist hviezdičkou
+ * - title necháme ako samostatný link
+ */
+remove_action('woocommerce_before_shop_loop_item', 'woocommerce_template_loop_product_link_open', 10);
+remove_action('woocommerce_after_shop_loop_item', 'woocommerce_template_loop_product_link_close', 5);
+remove_action('woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail', 10);
+remove_action('woocommerce_shop_loop_item_title', 'woocommerce_template_loop_product_title', 10);
+
+add_action('woocommerce_before_shop_loop_item_title', 'jtcollector_archive_product_image_with_wishlist', 10);
+add_action('woocommerce_shop_loop_item_title', 'jtcollector_archive_product_title_link', 10);
 ?>
 
 <main class="site-main shop-archive-page">
@@ -162,5 +217,13 @@ remove_action('woocommerce_after_shop_loop_item_title', 'jtcollector_archive_pro
 remove_action('woocommerce_after_shop_loop_item_title', 'woocommerce_template_loop_price', 11);
 remove_action('woocommerce_after_shop_loop_item_title', 'jtcollector_archive_price_stock_wrap_close', 12);
 add_action('woocommerce_after_shop_loop_item_title', 'woocommerce_template_loop_price', 10);
+
+remove_action('woocommerce_before_shop_loop_item_title', 'jtcollector_archive_product_image_with_wishlist', 10);
+remove_action('woocommerce_shop_loop_item_title', 'jtcollector_archive_product_title_link', 10);
+
+add_action('woocommerce_before_shop_loop_item', 'woocommerce_template_loop_product_link_open', 10);
+add_action('woocommerce_after_shop_loop_item', 'woocommerce_template_loop_product_link_close', 5);
+add_action('woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail', 10);
+add_action('woocommerce_shop_loop_item_title', 'woocommerce_template_loop_product_title', 10);
 
 get_footer();


### PR DESCRIPTION
## Popis
Doplnené wishlist hviezdičky na všetky hlavné produktové výpisy a detail produktu tak, aby bol wishlist vizuálne aj funkčne konzistentný v celom shope.

## Čo sa upravilo
- single product:
  - wishlist hviezdička v pravom hornom rohu rámčeka galérie
  - odstránené texty z YITH výstupu
  - ponechané farby riadené pluginom

- homepage / featured products:
  - pridaná wishlist hviezdička do pravého horného rohu rámčeka obrázka
  - samostatný wrapper pre obrázok + wishlist
  - menšia ikonka prispôsobená veľkosti produktovej karty

- archive products:
  - vlastný image wrapper s wishlist hviezdičkou cez WooCommerce hooky
  - wishlist mimo hlavného produktového odkazu, aby nevznikali vnorené linky
  - samostatný link pre obrázok a názov produktu
  - zachovaný existujúci layout ceny, skladu a tlačidla

## Výsledok
- wishlist hviezdičky sú jednotné na:
  - detaile produktu
  - homepage TOP kartách
  - archívnych výpisoch produktov
- hviezdičky neprekrývajú fotografiu ani pri zvislých a ani pri vodorovných kartách
- textové výstupy pluginu sú skryté, zobrazuje sa len ikonka
- farby sa preberajú priamo z nastavení YITH pluginu
- zachovaný čistý layout bez rozbitia gridu a klikacích zón

## Poznámka
Pri archive produktoch bola karta upravená cez hooky tak, aby bolo možné vložiť wishlist ako samostatný prvok bez HTML konfliktu s default WooCommerce linkom.