### PR TITLE
fix(layout): sticky footer for short content

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -141,3 +141,27 @@ a:hover{
     font-size: 1.75rem;
   }
 }
+
+/* ========================================
+   LAYOUT – footer dole len pri krátkom obsahu
+======================================== */
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header,
+.site-main,
+.site-footer {
+  width: 100%;
+}
+
+.site-main {
+  flex: 1 0 auto;
+}
+
+.site-footer {
+  margin-top: auto;
+}


### PR DESCRIPTION
Tento PR rieši problém s footerom, ktorý sa pri stránkach s malým množstvom obsahu nezobrazoval na spodnej hrane stránky.

Úprava zabezpečuje:
- footer je vždy dole pri krátkom obsahu
- pri dlhom obsahu sa správa štandardne

Riešenie je implementované pomocou flex layoutu (bez použitia absolute/fixed positioning), takže je stabilné a bez vedľajších efektov.

Bez vizuálnych regresií na existujúcich stránkach.