### PR TITLE
feat: hide WordPress admin bar for customers on frontend

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -363,4 +363,13 @@ function jtcollector_home_featured_products_shortcode() {
 	return ob_get_clean();
 }
 
+/**
+ * Skryje WordPress admin lištu pre zákazníkov a bežných používateľov na frontende.
+ */
+add_action('after_setup_theme', function () {
+	if (!is_admin() && !current_user_can('administrator')) {
+		show_admin_bar(false);
+	}
+});
+
 add_action('wp', 'jtcollector_single_related_products_hooks');


### PR DESCRIPTION
Skrytie WordPress admin lišty pre zákazníkov na frontende

Popis:

- Tento PR skrýva WordPress admin lištu pre zákazníkov a ostatných nepriviligovaných používateľov na frontende.
- Admin lišta zostáva zachovaná pre administrátora a v administrácii WordPressu sa správanie nemení.

Zmeny

- pridaná podmienka do functions.php
- skrytie admin lišty mimo administrácie
- administrátorovi zostáva lišta zachovaná