### PR TITLE
feat(popup): add add-to-cart popup with WooCommerce integration and UX improvements

### DIFF
--- a/assets/css/add-to-cart-popup.css
+++ b/assets/css/add-to-cart-popup.css
@@ -1,0 +1,277 @@
+/* ========================================
+   ADD TO CART POPUP
+======================================== */
+
+.jt-atc-popup[hidden] {
+  display: none !important;
+}
+
+.jt-atc-popup {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+}
+
+.jt-atc-popup__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.36);
+  opacity: 0;
+  transition: opacity 0.22s ease;
+}
+
+.jt-atc-popup__dialog {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(100% - 32px, 720px);
+  max-height: calc(100vh - 32px);
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #d9e9fb;
+  border-radius: 24px;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+  transform: translate(-50%, -50%) scale(0.96);
+  opacity: 0;
+  transition: transform 0.24s ease, opacity 0.24s ease;
+}
+
+.jt-atc-popup.is-visible .jt-atc-popup__overlay {
+  opacity: 1;
+}
+
+.jt-atc-popup.is-visible .jt-atc-popup__dialog {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.jt-atc-popup__inner {
+  padding: 28px 28px 24px;
+  box-sizing: border-box;
+}
+
+.jt-atc-popup__close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: #f8fbff;
+  color: #194b9b;
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.18s ease, color 0.18s ease;
+}
+
+.jt-atc-popup__close:hover,
+.jt-atc-popup__close:focus-visible {
+  background: #eef6ff;
+  color: #0f3b78;
+  outline: none;
+}
+
+.jt-atc-popup__status {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding-right: 34px;
+  margin-bottom: 20px;
+}
+
+.jt-atc-popup__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  min-width: 34px;
+  border-radius: 999px;
+  background: #ecfdf3;
+  color: #15803d;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.jt-atc-popup__heading h3 {
+  margin: 0 0 4px;
+  font-size: 1.35rem;
+  line-height: 1.15;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.jt-atc-popup__heading p {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.55;
+  color: #64748b;
+}
+
+.jt-atc-popup__product {
+  display: grid;
+  grid-template-columns: 132px minmax(0, 1fr);
+  gap: 20px;
+  align-items: center;
+  padding: 18px 0;
+  border-top: 1px solid #dbe3ee;
+  border-bottom: 1px solid #dbe3ee;
+}
+
+.jt-atc-popup__image-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 132px;
+  height: 132px;
+  padding: 10px;
+  background: #f8fafc;
+  border: 1px solid #d9e9fb;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.jt-atc-popup__image {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  object-position: center;
+}
+
+.jt-atc-popup__content {
+  min-width: 0;
+}
+
+.jt-atc-popup__product-name {
+  margin: 0 0 8px;
+  font-size: 1.08rem;
+  line-height: 1.4;
+  font-weight: 400;
+  color: #0f172a;
+}
+
+.jt-atc-popup__product-price {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.2;
+  font-weight: 700;
+  color: #3095e8;
+}
+
+.jt-atc-popup__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-top: 20px;
+}
+
+.jt-atc-popup__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 18px;
+  border-radius: 999px;
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none !important;
+  transition: filter 0.18s ease, opacity 0.18s ease, background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.jt-atc-popup__button--primary {
+  border: 0;
+  background: linear-gradient(135deg, #3095e8 0%, #194b9b 100%);
+  color: #fff !important;
+  box-shadow: 0 2px 6px rgba(29, 78, 216, 0.12);
+}
+
+.jt-atc-popup__button--primary:hover,
+.jt-atc-popup__button--primary:focus-visible {
+  color: #fff !important;
+  filter: brightness(1.08);
+  outline: none;
+}
+
+.jt-atc-popup__button--ghost {
+  border: 1px solid #d9e9fb;
+  background: #fff;
+  color: #194b9b;
+}
+
+.jt-atc-popup__button--ghost:hover,
+.jt-atc-popup__button--ghost:focus-visible {
+  background: #f8fbff;
+  color: #0f3b78;
+  border-color: #9fc5f8;
+  outline: none;
+}
+
+body.jt-atc-popup-open {
+  overflow: hidden;
+}
+
+@media (max-width: 640px) {
+  .jt-atc-popup__dialog {
+    width: min(100% - 20px, 720px);
+    border-radius: 18px;
+  }
+
+  .jt-atc-popup__inner {
+    padding: 22px 16px 18px;
+  }
+
+  .jt-atc-popup__status {
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .jt-atc-popup__heading h3 {
+    font-size: 1.16rem;
+  }
+
+  .jt-atc-popup__heading p {
+    font-size: 0.93rem;
+  }
+
+    .jt-atc-popup__product {
+    grid-template-columns: 88px minmax(0, 1fr);
+    gap: 14px;
+    padding: 14px 0;
+    }
+
+    .jt-atc-popup__image-wrap {
+    width: 88px;
+    height: 88px;
+    padding: 8px;
+    }
+
+  .jt-atc-popup__product-name {
+    font-size: 0.98rem;
+  }
+
+  .jt-atc-popup__product-price {
+    font-size: 1rem;
+  }
+
+  .jt-atc-popup__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .jt-atc-popup__button {
+    width: 100%;
+  }
+}

--- a/assets/js/add-to-cart-popup.js
+++ b/assets/js/add-to-cart-popup.js
@@ -1,0 +1,393 @@
+(function ($) {
+  'use strict';
+
+  let autoCloseTimer = null;
+  let canClosePopup = false;
+  let pendingData = null;
+  let justOpenedAt = 0;
+  let popupOpenedViaAjax = false;
+
+  function getPopupElements() {
+    const popup = document.querySelector('.jt-atc-popup');
+
+    if (!popup) {
+      return null;
+    }
+
+    return {
+      popup,
+      dialog: popup.querySelector('.jt-atc-popup__dialog'),
+      overlay: popup.querySelector('.jt-atc-popup__overlay'),
+      image: popup.querySelector('.jt-atc-popup__image'),
+      productName: popup.querySelector('.jt-atc-popup__product-name'),
+      productPrice: popup.querySelector('.jt-atc-popup__product-price'),
+      title: popup.querySelector('#jt-atc-popup-title'),
+      description: popup.querySelector('#jt-atc-popup-text'),
+      cartButton: popup.querySelector('.jt-atc-popup__button--primary'),
+      closeButtons: popup.querySelectorAll('[data-jt-popup-close]')
+    };
+  }
+
+  function clearAutoClose() {
+    if (autoCloseTimer) {
+      window.clearTimeout(autoCloseTimer);
+      autoCloseTimer = null;
+    }
+  }
+
+  function normalizeText(value) {
+    return value ? value.replace(/\s+/g, ' ').trim() : '';
+  }
+
+  function getBestImageFromElement($context) {
+    if (!$context || !$context.length) {
+      return '';
+    }
+
+    const $img = $context.find('img').first();
+
+    if (!$img.length) {
+      return '';
+    }
+
+    return (
+      $img.attr('data-large_image') ||
+      $img.attr('data-src') ||
+      $img.attr('data-lazy-src') ||
+      $img.attr('src') ||
+      ''
+    );
+  }
+
+  function savePendingToSession(data) {
+    if (!data) {
+      return;
+    }
+
+    try {
+      sessionStorage.setItem('jt_atc_popup_pending', JSON.stringify(data));
+    } catch (error) {
+      // ignore
+    }
+  }
+
+  function readPendingFromSession() {
+    try {
+      const storedData = sessionStorage.getItem('jt_atc_popup_pending');
+
+      if (!storedData) {
+        return null;
+      }
+
+      sessionStorage.removeItem('jt_atc_popup_pending');
+      return JSON.parse(storedData);
+    } catch (error) {
+      sessionStorage.removeItem('jt_atc_popup_pending');
+      return null;
+    }
+  }
+
+  function shouldSkipPopupForButton(button) {
+    const $button = $(button);
+    return $button.closest('.jt-empty-cart-featured').length > 0;
+  }
+
+  function openPopup(data) {
+    const els = getPopupElements();
+
+    if (!els) {
+      return;
+    }
+
+    clearAutoClose();
+    canClosePopup = false;
+    justOpenedAt = Date.now();
+
+    const image = data.image || (window.jtAddToCartPopup && window.jtAddToCartPopup.defaultImage) || '';
+    const name = data.name || 'Produkt bol pridaný do košíka';
+    const price = data.price || '';
+    const description = data.description || 'Produkt bol úspešne pridaný do košíka.';
+
+    if (image) {
+      els.image.src = image;
+      els.image.alt = name;
+    } else {
+      els.image.alt = '';
+    }
+
+    els.productName.textContent = name;
+    els.productPrice.textContent = price;
+    els.productPrice.style.display = price ? '' : 'none';
+
+    els.title.textContent =
+      (window.jtAddToCartPopup && window.jtAddToCartPopup.successText) ||
+      'Produkt bol pridaný do košíka';
+
+    els.description.textContent = description;
+
+    if (els.cartButton && window.jtAddToCartPopup && window.jtAddToCartPopup.cartUrl) {
+      els.cartButton.setAttribute('href', window.jtAddToCartPopup.cartUrl);
+    }
+
+    els.popup.hidden = false;
+
+    window.requestAnimationFrame(function () {
+      els.popup.classList.add('is-visible');
+      document.body.classList.add('jt-atc-popup-open');
+    });
+
+    window.setTimeout(function () {
+      canClosePopup = true;
+    }, 220);
+
+    if (
+      window.jtAddToCartPopup &&
+      Number(window.jtAddToCartPopup.autoCloseDelay) > 0
+    ) {
+      autoCloseTimer = window.setTimeout(closePopup, Number(window.jtAddToCartPopup.autoCloseDelay));
+    }
+
+    pendingData = null;
+  }
+
+  function closePopup(force) {
+    const els = getPopupElements();
+
+    if (!els) {
+      return;
+    }
+
+    if (!force && (!canClosePopup || Date.now() - justOpenedAt < 180)) {
+      return;
+    }
+
+    clearAutoClose();
+
+    els.popup.classList.remove('is-visible');
+    document.body.classList.remove('jt-atc-popup-open');
+
+    window.setTimeout(function () {
+      if (!els.popup.classList.contains('is-visible')) {
+        els.popup.hidden = true;
+      }
+    }, 240);
+  }
+
+  function getArchiveOrFeaturedData(button) {
+    const $button = $(button);
+    const $product = $button.closest('.product, li.product');
+    const $fallbackCard = $button.closest('[class*="product"], [class*="shop-home"]');
+    const $scope = $product.length ? $product : $fallbackCard;
+
+    const $title = $scope.find('.woocommerce-loop-product__title').first();
+    const $price = $scope.find('.price').first();
+
+    return {
+      name: normalizeText($title.text()),
+      price: normalizeText($price.text()),
+      image: getBestImageFromElement($scope),
+      description: 'Produkt bol úspešne pridaný do košíka.'
+    };
+  }
+
+    function getSingleProductData(button) {
+    const $button = $(button);
+
+    const $productRoot = $('.single-product .product').first().length
+        ? $('.single-product .product').first()
+        : $('main .product').first();
+
+    const $title = $productRoot.find('.product_title').first().length
+        ? $productRoot.find('.product_title').first()
+        : $('h1.product_title, .product h1, .jt-single-product h1').first();
+
+    const $price = $productRoot.find('.summary .price').first().length
+        ? $productRoot.find('.summary .price').first()
+        : $('.summary .price, .jt-single-product__summary .price, .jt-single-product .price').first();
+
+    const $galleryImg = $('.woocommerce-product-gallery__image img').first().length
+        ? $('.woocommerce-product-gallery__image img').first()
+        : $('.jt-single-product__gallery-frame img, .jt-single-product img.wp-post-image, .product img.wp-post-image').first();
+
+    let image = '';
+    if ($galleryImg.length) {
+        image =
+        $galleryImg.attr('data-large_image') ||
+        $galleryImg.attr('data-src') ||
+        $galleryImg.attr('data-lazy-src') ||
+        $galleryImg.attr('src') ||
+        '';
+    }
+
+    const name = normalizeText($title.text());
+    const price = normalizeText($price.text());
+
+    return {
+        name: name || 'Produkt bol pridaný do košíka',
+        price: price || '',
+        image: image,
+        description: 'Produkt bol úspešne pridaný do košíka.'
+    };
+  }
+
+  function getFallbackNoticeData() {
+    const $notice = $('.woocommerce-message, .wc-block-components-notice-banner, .woocommerce-notices-wrapper .message, .woocommerce-notices-wrapper .woocommerce-message').first();
+
+    if (!$notice.length) {
+      return null;
+    }
+
+    const noticeText = normalizeText($notice.text());
+
+    if (
+      noticeText.indexOf('bol pridaný do košíka') === -1 &&
+      noticeText.indexOf('has been added to your cart') === -1
+    ) {
+      return null;
+    }
+
+    let productName = '';
+    const $noticeLink = $notice.find('a').not('.button, .restore-item').last();
+
+    if ($noticeLink.length) {
+      productName = normalizeText($noticeLink.text());
+    }
+
+    return {
+      name: productName || 'Produkt bol pridaný do košíka',
+      price: '',
+      image: '',
+      description: 'Produkt bol úspešne pridaný do košíka.'
+    };
+  }
+
+  function bindPopupClose() {
+    const els = getPopupElements();
+
+    if (!els) {
+      return;
+    }
+
+    els.closeButtons.forEach(function (button) {
+      button.addEventListener('click', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        closePopup(true);
+      });
+    });
+
+    if (els.overlay) {
+      els.overlay.addEventListener('click', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        closePopup();
+      });
+    }
+
+    if (els.dialog) {
+      els.dialog.addEventListener('click', function (event) {
+        event.stopPropagation();
+      });
+
+      els.dialog.addEventListener('mousedown', function (event) {
+        event.stopPropagation();
+      });
+    }
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') {
+        closePopup(true);
+      }
+    });
+  }
+
+  function bindAddToCartEvents() {
+    $(document).on('click', '.add_to_cart_button, .ajax_add_to_cart, .single_add_to_cart_button', function () {
+      const button = this;
+      const $button = $(button);
+      const isSingle =
+        $button.hasClass('single_add_to_cart_button') ||
+        $('body').hasClass('single-product');
+
+      if (shouldSkipPopupForButton(button)) {
+        pendingData = null;
+
+        try {
+          sessionStorage.removeItem('jt_atc_popup_pending');
+        } catch (error) {
+          // ignore
+        }
+
+        return;
+      }
+
+      pendingData = isSingle
+        ? getSingleProductData(button)
+        : getArchiveOrFeaturedData(button);
+
+      popupOpenedViaAjax = false;
+      savePendingToSession(pendingData);
+    });
+
+    $(document.body).on('added_to_cart', function (event, fragments, cartHash, $button) {
+      if ($button && $button.length && shouldSkipPopupForButton($button.get(0))) {
+        try {
+          sessionStorage.removeItem('jt_atc_popup_pending');
+        } catch (error) {
+          // ignore
+        }
+        return;
+      }
+
+      popupOpenedViaAjax = true;
+
+      if (pendingData) {
+        openPopup(pendingData);
+      } else {
+        openPopup({
+          name: 'Produkt bol pridaný do košíka',
+          price: '',
+          image: '',
+          description: 'Produkt bol úspešne pridaný do košíka.'
+        });
+      }
+
+      try {
+        sessionStorage.removeItem('jt_atc_popup_pending');
+      } catch (error) {
+        // ignore
+      }
+    });
+
+    $(document).on('submit', 'form.cart', function () {
+      const data = getSingleProductData($(this).find('.single_add_to_cart_button').get(0) || this);
+      pendingData = data;
+      savePendingToSession(data);
+    });
+
+    const storedData = readPendingFromSession();
+
+    if (storedData && !($('.woocommerce-cart .jt-empty-cart-featured').length > 0)) {
+      window.setTimeout(function () {
+        openPopup(storedData);
+      }, 260);
+    } else {
+      const fallbackData = getFallbackNoticeData();
+
+      if (fallbackData && !popupOpenedViaAjax) {
+        window.setTimeout(function () {
+          openPopup(fallbackData);
+        }, 260);
+      }
+    }
+  }
+
+  $(function () {
+    if (!$('.jt-atc-popup').length) {
+      return;
+    }
+
+    bindPopupClose();
+    bindAddToCartEvents();
+  });
+})(jQuery);

--- a/functions.php
+++ b/functions.php
@@ -389,4 +389,123 @@ add_action('after_setup_theme', function () {
 	}
 });
 
+/**
+ * WooCommerce pages where add-to-cart popup makes sense.
+ */
+if (!function_exists('jtcollector_should_load_add_to_cart_popup')) {
+	function jtcollector_should_load_add_to_cart_popup(): bool
+	{
+		return is_front_page() || is_home() || is_shop() || is_product_taxonomy() || is_product() || is_cart() || is_page('wishlist');
+	}
+}
+
+/**
+ * Enqueue add-to-cart popup assets.
+ */
+if (!function_exists('jtcollector_enqueue_add_to_cart_popup_assets')) {
+	function jtcollector_enqueue_add_to_cart_popup_assets(): void
+	{
+		if (!jtcollector_should_load_add_to_cart_popup()) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'jtcollector-add-to-cart-popup',
+			get_template_directory_uri() . '/assets/css/add-to-cart-popup.css',
+			['jtcollector-main-style', 'jtcollector-woocommerce'],
+			jtcollector_asset_version('/assets/css/add-to-cart-popup.css')
+		);
+
+		wp_enqueue_script(
+			'jtcollector-add-to-cart-popup',
+			get_template_directory_uri() . '/assets/js/add-to-cart-popup.js',
+			['jquery'],
+			jtcollector_asset_version('/assets/js/add-to-cart-popup.js'),
+			true
+		);
+
+		wp_localize_script('jtcollector-add-to-cart-popup', 'jtAddToCartPopup', [
+			'cartUrl'          => wc_get_cart_url(),
+			'continueText'     => 'Pokračovať v nákupe',
+			'cartText'         => 'Pokračovať do košíka',
+			'successText'      => 'Produkt bol pridaný do košíka',
+			'defaultImage'     => wc_placeholder_img_src('woocommerce_thumbnail'),
+			'autoCloseDelay'   => 0,
+		]);
+	}
+}
+add_action('wp_enqueue_scripts', 'jtcollector_enqueue_add_to_cart_popup_assets', 30);
+
+/**
+ * Popup markup in footer.
+ */
+if (!function_exists('jtcollector_render_add_to_cart_popup')) {
+	function jtcollector_render_add_to_cart_popup(): void
+	{
+		if (!jtcollector_should_load_add_to_cart_popup()) {
+			return;
+		}
+		?>
+		<div class="jt-atc-popup" hidden>
+			<div class="jt-atc-popup__overlay" data-jt-popup-close></div>
+
+			<div
+				class="jt-atc-popup__dialog"
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="jt-atc-popup-title"
+				aria-describedby="jt-atc-popup-text"
+			>
+				<button
+					type="button"
+					class="jt-atc-popup__close"
+					aria-label="Zatvoriť okno"
+					data-jt-popup-close
+				>
+					<span aria-hidden="true">&times;</span>
+				</button>
+
+				<div class="jt-atc-popup__inner">
+					<div class="jt-atc-popup__status">
+						<span class="jt-atc-popup__icon" aria-hidden="true">✓</span>
+
+						<div class="jt-atc-popup__heading">
+							<h3 id="jt-atc-popup-title">Produkt bol pridaný do košíka</h3>
+							<p id="jt-atc-popup-text">Tovar je pripravený v košíku.</p>
+						</div>
+					</div>
+
+					<div class="jt-atc-popup__product">
+						<div class="jt-atc-popup__image-wrap">
+							<img
+								class="jt-atc-popup__image"
+								src="<?php echo esc_url(wc_placeholder_img_src('woocommerce_thumbnail')); ?>"
+								alt=""
+								loading="lazy"
+							>
+						</div>
+
+						<div class="jt-atc-popup__content">
+							<p class="jt-atc-popup__product-name"></p>
+							<p class="jt-atc-popup__product-price"></p>
+						</div>
+					</div>
+
+					<div class="jt-atc-popup__actions">
+						<button type="button" class="jt-atc-popup__button jt-atc-popup__button--ghost" data-jt-popup-close>
+							Pokračovať v nákupe
+						</button>
+
+						<a class="jt-atc-popup__button jt-atc-popup__button--primary" href="<?php echo esc_url(wc_get_cart_url()); ?>">
+							Pokračovať do košíka
+						</a>
+					</div>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+}
+add_action('wp_footer', 'jtcollector_render_add_to_cart_popup', 120);
+
 add_action('wp', 'jtcollector_single_related_products_hooks');


### PR DESCRIPTION
## 🧩 Popis

Implementácia popup okna po pridaní produktu do košíka (Issue #55).

Popup poskytuje okamžitú spätnú väzbu používateľovi a umožňuje:
- pokračovať v nákupe
- prejsť priamo do košíka

---

## 🎯 Funkcionalita

- zobrazenie popupu po kliknutí na „Pridať do košíka“
- podpora:
  - AJAX add to cart (archive, homepage)
  - fallback pri reloadnutí stránky (single-product)
- dynamický obsah:
  - názov produktu
  - cena
  - obrázok
- CTA tlačidlá:
  - „Pokračovať v nákupe“
  - „Pokračovať do košíka“

---

## 🎨 Dizajn

Popup je vizuálne zladený s JTCollector:

- border-radius: 24px
- jemný shadow
- farby a typografia podľa existujúcich komponentov
- CTA tlačidlá využívajú rovnaký gradient ako „Pridať do košíka“

---

## ⚙️ Technické riešenie

- nový JS súbor:
  - `assets/js/add-to-cart-popup.js`
- nový CSS súbor:
  - `assets/css/add-to-cart-popup.css`
- WooCommerce event:
  - `added_to_cart`
- fallback:
  - `sessionStorage` pre reload flow

---

## 🧠 Špeciálne správanie

- popup je vypnutý pre sekciu:
  - prázdny košík → „TOP karty z ponuky“
- dôvod:
  - košík sa okamžite aktualizuje → popup by bol redundantný

---

## ✅ Acceptance criteria

- popup sa zobrazí po pridaní produktu
- funguje pre AJAX aj reload flow
- obsahuje názov, cenu a obrázok
- obsahuje CTA tlačidlá
- zatvára sa:
  - klik mimo
  - klik na X
  - ESC
- vizuálne zapadá do dizajnu webu

---

## 🚀 Výsledok

Zlepšenie UX a jasnej spätné väzby používateľovi pri práci s košíkom.